### PR TITLE
Font selecting

### DIFF
--- a/src/encode.rkt
+++ b/src/encode.rkt
@@ -54,6 +54,8 @@
   (define prefix (slower type))
   (match value
     [(? symbol?) (sformat "~a/~a" prefix value)]
+    [(? string?) (let ([str (if (equal? value "-moz-field") "Sans" value)])
+                   (list (sformat "~a/num" prefix) (name 'type str)))] ;; TODO: Default input font instead of "Sans"
     [0 (list (sformat "~a/px" prefix) 0)]
     [(? number?) (list (sformat "~a/num" prefix) (number->z3 value))]
     [(list 'em n) (list (sformat "~a/em" prefix) (number->z3 n))]

--- a/src/main.rkt
+++ b/src/main.rkt
@@ -115,8 +115,7 @@
 
   (for ([rm ml])
     (match-define (list selector (? attribute? attrs) ... (and (or (? list?) '?) props) ...) (rulematch-rule rm))
-    (for ([(prop type default) (in-css-properties)] #:when (rule-allows-property? (rulematch-rule rm) prop)
-	      #:unless (or (equal? prop 'font-family) (equal? prop 'font-style) (equal? prop 'font-weight)))
+    (for ([(prop type default) (in-css-properties)] #:when (rule-allows-property? (rulematch-rule rm) prop))
       (define propname (sformat "value/~a/~a" (rulematch-idx rm) prop))
       (cond
        [(equal? '? (car (dict-ref (filter list? props) prop '(?))))
@@ -137,8 +136,7 @@
     (define style `(specified-style ,(dump-elt elt)))
     (for ([elt (cdr cls)])
       (emit `(assert (= (specified-style ,(dump-elt elt)) ,style))))
-    (for* ([(prop type default) (in-css-properties)]
-           #:unless (or (equal? prop 'font-family) (equal? prop 'font-style) (equal? prop 'font-weight)))
+    (for* ([(prop type default) (in-css-properties)])
       (define nonecond
         (for/fold ([no-match-so-far 'true])
             ([rm ml]

--- a/src/match.rkt
+++ b/src/match.rkt
@@ -1,7 +1,7 @@
 #lang racket
 
 (require "common.rkt" "tree.rkt" "selectors.rkt")
-(provide link-elts-boxes link-matched-elts-boxes sheet->font)
+(provide link-elts-boxes link-matched-elts-boxes)
 
 (define (sheet->display elts sheet)
   (if (ormap (curryr set-member? '?) sheet)
@@ -12,20 +12,6 @@
           (if (equal? (node-type elt) 'head)
               'none
               (dict-ref value-hash (dict-ref class-hash elt)))))))
-
-(define (sheet->font elts sheet)
-  (if (ormap (curryr set-member? '?) sheet)
-      (λ (elt) (if (equal? (node-type elt) 'head) 'none '?))
-      (let ([eqs (equivalence-classes sheet elts)])
-        (λ (elt)
-          (match-define (cons class-hash-family value-hash-family) (dict-ref eqs 'font-family))
-          (match-define (cons class-hash-weight value-hash-weight) (dict-ref eqs 'font-weight))
-          (match-define (cons class-hash-style value-hash-style) (dict-ref eqs 'font-style))
-          (if (equal? (node-type elt) 'head)
-              'none
-              (list (dict-ref value-hash-family (dict-ref class-hash-family elt))
-                    (dict-ref value-hash-weight (dict-ref class-hash-weight elt))
-                    (dict-ref value-hash-style (dict-ref class-hash-style elt))))))))
 
 (define (link-matched-elts-boxes sheet elts boxes)
   (define num->elt (make-hasheq))

--- a/src/spec/compute-style.rkt
+++ b/src/spec/compute-style.rkt
@@ -25,7 +25,7 @@
   (append
    '(border-top-style border-right-style border-bottom-style border-left-style)
    '(text-align overflow-x overflow-y position color background-color)
-   '(clear display box-sizing)))
+   '(clear display box-sizing font-weight font-style font-family)))
 
 (define em-computed-properties
   ;; These are properties whose computed style must convert em values to pixels

--- a/src/spec/compute-style.rkt
+++ b/src/spec/compute-style.rkt
@@ -150,6 +150,6 @@
   (check equal?
          (sort
           (append simple-computed-properties em-computed-properties
-                  '(height float border-top-width border-right-width border-bottom-width border-left-width font-size line-height font-family font-weight font-style))
+                  '(height float border-top-width border-right-width border-bottom-width border-left-width font-size line-height))
           string<? #:key symbol->string)
          (sort (css-properties) string<? #:key symbol->string)))

--- a/src/spec/css-properties.rkt
+++ b/src/spec/css-properties.rkt
@@ -96,13 +96,13 @@
   [font-size (em 1)])
 
 ; Font Family is a string so should never make it to Z3
-(define-css-type (Font-Family)
+(define-css-type (Font-Family (num Real))
   [font-family "serif"])
 
-(define-css-type (Font-Weight normal bold bolder lighter (num Real) initial inherit)
+(define-css-type (Font-Weight bolder lighter (num Real) initial)
   [font-weight 400])
 
-(define-css-type (Font-Style normal italic oblique initial inherit)
+(define-css-type (Font-Style normal italic oblique initial)
   [font-style normal])
 
 (define-css-type (Text-Indent (px Real) (% Real) (em Real))

--- a/src/spec/fonts.rkt
+++ b/src/spec/fonts.rkt
@@ -54,7 +54,7 @@
           `(ite (and (= family ,(dump-value 'font-family family))
                      (= weight  ,(if (number? weight) `(font-weight/num ,weight) (sformat "font-weight/~a" weight)))
                      (= style ,(sformat "font-style/~a" style))
-                     ,(fuzzy-=-constraint 'font-size size *font-fuzz*))
+                     ,(fuzzy-=-constraint 'font-size size *fuzz*))
                 ,metric
                 ,inner)))))
 

--- a/src/spec/utils.rkt
+++ b/src/spec/utils.rkt
@@ -44,7 +44,7 @@
       (Element no-elt
            (elt (specified-style Style) (computed-style Style) ; see compute-style.rkt
                 (is-replaced Bool) (is-image Bool) (intrinsic-width Real) (intrinsic-height Real)
-                (&pelt Int) (&velt Int) (&nelt Int) (&felt Int) (&lelt Int) (font Font-Metric)))))
+                (&pelt Int) (&velt Int) (&nelt Int) (&felt Int) (&lelt Int)))))
 
   ,@(for/list ([field '(&pelt &velt &nelt &felt &lelt)])
       `(assert (= (,field no-elt) -1)))


### PR DESCRIPTION
Font information is now passed through to Z3 to assign metrics to boxes. Removed old fid code from Racket.