### PR TITLE
Refactor main.rkt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ previous/
 # Racket and TypeScript junk
 src/compiled/
 __pycache__
-capture/*.js
+capture/all.js
 
 # Platform junk
 *.bak

--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,8 @@ nightly:
 setup: capture/all.js
 
 # We do not exactly need Rollup or Webpack here...
-capture/all.js: $(filter-out capture/all.js, $(wildcard capture/*.js) $(wildcard capture/*.ts))
-	tsc --project capture/
-	echo "exports = window; function require() { return window; }" | \
-	    cat - $(filter-out capture/all.js, $(wildcard capture/*.js)) > $@
+capture/all.js: $(wildcard capture/*.ts) capture/tsconfig.json capture/shim.js
+	tsc --project capture/ && cat capture/shim.js >> $@
 
 # CSSWG test suite
 

--- a/README.md
+++ b/README.md
@@ -34,14 +34,10 @@ First, set up Cassius with:
 
 Then, test out your Cassius installation by running, from the top-level directory,
 
-    python3 capture/capture.py http://example.com --output bench/example.rkt
+    python3 capture/capture.py http://example.com/ --output bench/example.rkt
     racket src/run.rkt accept bench/example.rkt doc-1
 
 This should churn for a few seconds and say, "Accepted".
-
-If you receive a Selenium / JavaScript error, it often helps to:
-
-    make -B capture/all.js
 
 Capturing Web Pages
 -------------------
@@ -61,15 +57,8 @@ stores one web pages for each given URL. They are named `doc-00N`, for
 (these names are referred to as "instances").
 
 Some pages need to be modified before being captured. The `--prerun
-[js-file]` flag allows you to specify a file of JavaScript to be run
-before capturing the page.
-
-*Note*: The capture script starts a full web browser, so may take a
-while to complete. It also creates a visible browser window. Do not
-interact with this window! On Linux machines, it is convenient to use
-the `xvfb-run` command to hide this window, like so:
-
-    xvfb-run -a python3 capture/capture.py [urls ...] --output [file]
+[js-file]` flag allows you to run a JavaScript file before capturing
+the page.
 
 Testing if a Web Page is Supported
 ----------------------------------
@@ -83,7 +72,7 @@ you passed several URLs to the `capture.py` script.
 
 This will churn for a while and output either "Accepted" or
 "Rejected". If "Accepted" is produced, that means that Cassius's
-formalization of browser rendering accepts to rendering produced by
+formalization of browser rendering accepts the rendering produced by
 Firefox, a good proxy for whether Cassius supports your web page.
 
 Cassius currently supports a fragment of CSS 2.1:

--- a/capture/shim.js
+++ b/capture/shim.js
@@ -1,0 +1,3 @@
+function define(name, deps, fn) {
+    fn.apply(window, deps.map(function() { return window; }));
+}

--- a/capture/tsconfig.json
+++ b/capture/tsconfig.json
@@ -10,6 +10,8 @@
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "strictPropertyInitialization": true,
+        "outFile": "./all.js",
+        "module": "amd",
     },
     "include": [ "*.ts" ]
 }

--- a/src/main.rkt
+++ b/src/main.rkt
@@ -4,23 +4,18 @@
 (require "spec/css-properties.rkt" "spec/tree.rkt" "spec/compute-style.rkt" "spec/layout.rkt"
          "spec/percentages.rkt" "spec/utils.rkt" "spec/float.rkt" "spec/colors.rkt" "spec/fonts.rkt"
          "spec/media-query.rkt" "assertions.rkt" "spec/replaced-elements.rkt")
-(provide all-constraints add-test selector-constraints model-sufficiency)
+(provide all-constraints add-test model-sufficiency)
 
 (define (tree-constraints dom emit elt)
   (emit `(assert (= (pelt ,(dump-elt elt)) ,(dump-elt (node-parent elt))))))
-
-(define (rule-allows-property? rule prop)
-  (match-define (list selector (? attribute? attrs) ... (and (or (? list?) '?) props) ...) rule)
-  (or (set-member? props '?)
-      (and (dict-has-key? props prop)
-           (not (null? (dict-ref props prop))))))
 
 (define (selector-constraints media-params emit elts rules)
   (define ml (rule-matchlist rules elts))
 
   (for ([rm ml])
     (match-define (list selector (? attribute? attrs) ... (and (or (? list?) '?) props) ...) (rulematch-rule rm))
-    (for ([(prop type default) (in-css-properties)] #:when (rule-allows-property? (rulematch-rule rm) prop))
+    (for ([(prop type default) (in-css-properties)]
+          #:when (rule-allows-property? (rulematch-rule rm) prop))
       (define propname (sformat "value/~a/~a" (rulematch-idx rm) prop))
       (cond
        [(equal? '? (car (dict-ref (filter list? props) prop '(?))))

--- a/src/main.rkt
+++ b/src/main.rkt
@@ -3,60 +3,8 @@
 (require "common.rkt" "dom.rkt" "smt.rkt" "encode.rkt" "tree.rkt" "selectors.rkt")
 (require "spec/css-properties.rkt" "spec/tree.rkt" "spec/compute-style.rkt" "spec/layout.rkt"
          "spec/percentages.rkt" "spec/utils.rkt" "spec/float.rkt" "spec/colors.rkt" "spec/fonts.rkt"
-         "spec/media-query.rkt" "assertions.rkt" "spec/replaced-elements.rkt")
-(provide all-constraints add-test model-sufficiency)
-
-;; Is the model valid?
-
-(define (model-sufficiency doms)
-  (apply smt-and
-         (for*/list ([dom doms] [box (in-boxes dom)])
-           `(ez.sufficient ,(dump-box box)))))
-
-;; Adding assertions to the constraints
-
-(define (add-test doms tests #:component [component #f] #:render? [render? true])
-  (match-define (list dom) doms)
-  (define possible-boxes
-    (if component
-        (nodes-below component  '(:pre :spec :assert :admit))
-        (for/list ([box (in-boxes dom)]) box)))
-  `((declare-const which-constraint Real)
-    ,@(for/reap [sow] ([test tests] [id (in-naturals)]
-                       #:when true
-                       [(var cexvar) (in-dict (car test))])
-        (define var-values
-          (or (not-true-inputs (cdr test) (list var) dom)
-              (map dump-box possible-boxes)))
-        (sow `(declare-const ,cexvar Box))
-        (sow `(assert ,(apply smt-or (for/list ([boxvar var-values]) `(= ,cexvar ,boxvar))))))
-    (assert ,(apply smt-or
-                    (for/list ([test tests] [i (in-naturals)])
-                      `(and (not ,(cdr test)) (= which-constraint ,i)))))
-    ,@(reap [sow]
-         (for ([box (in-boxes dom)])
-           (spec-constraints (if render? '(:spec) '(:spec :assert :admit)) dom sow box)))))
-
-(define (spec-constraints fields dom emit box)
-  (when (ormap (curry node-get* box) fields)
-    (define nodes (nodes-below box (λ (x) (ormap (curry node-get* x) fields))))
-    (define pres (node-get* box ':pre #:default '()))
-
-    (for ([field fields] #:when (node-get* box field) [test (node-get* box field)] [i (in-naturals)])
-      (define-values (vars body) (disassemble-forall test))
-
-      (define ctx
-        (hash-union
-         (for/hash ([var vars]) (values var var))
-         (hash '? (dump-box box))
-         (get-node-names nodes)))
-      (define spec (compile-assertion (list dom) `(=> ,@pres ,body) ctx))
-
-      (for ([vals (apply cartesian-product (map (const nodes) vars))] [j (in-naturals)])
-        (define body* (massage-body spec (map cons vars vals) dom))
-        (unless (equal? body* 'true)
-          (emit `(assert (let ,(map (λ (v x) (list v (dump-box x))) vars vals) ,body*))))))))
-
+         "spec/media-query.rkt" "assertions.rkt" "spec/replaced-elements.rkt" "modularize.rkt")
+(provide all-constraints)
 
 ;; The constraints
 
@@ -189,9 +137,6 @@
 
     (emit `(assert (! ,constraint :named ,(sformat "~a/~a" fun (node-id elt)))))))
 
-(define (is-component box)
-  (or (not (node-parent box)) (node-get* box ':split)))
-
 (define (box-tree-constraints dom emit box)
   (define link-function
     (if (dom-context dom ':component)
@@ -208,62 +153,6 @@
                   ,(dump-box (node-fchild box))
                   ,(dump-box (node-lchild box))))))
 
-(define (nodes-below node stop?)
-  (reap [sow]
-        (let loop ([node node])
-          (sow node)
-          (for ([child (node-children node)])
-            (if (stop? child)
-                (sow child)
-                (loop child))))))
-
-(define (get-node-names nodes)
-  (for/hash ([node nodes] #:when (node-get node ':name #:default false))
-    (values (node-get node ':name) (dump-box node))))
-
-(define (my-set-intersect . as)
-  (foldl (λ (set acc) (if set (if acc (set-intersect set acc) set) acc)) #f as))
-
-(define (my-set-union . as)
-  (foldl (λ (set acc) (if set (if acc (set-union set acc) #f) #f)) '() as))
-
-(define (not-true-inputs body ctx dom)
-  (match body
-    [`(=> ,conds ... ,post)
-     (apply my-set-union (not-true-inputs post ctx dom)
-            (map (curryr not-false-inputs ctx dom) conds))]
-    [`(and ,bits ...)
-     (apply my-set-union (map (curryr not-true-inputs ctx dom) bits))]
-    [_ '()]))
-
-(define (not-false-inputs body ctx dom)
-  (match body
-    [`(or ,bits ...)
-     (apply my-set-union (map (curryr not-false-inputs ctx dom) bits))]
-    [`(= ,(? (curry set-member? ctx) b)
-         ,(app ~a (regexp #rx"^box([0-9]+)$" (list bname _))))
-     (list (cons b bname))]
-    [_ #f]))
-
-(define (massage-body body ctx dom)
-  (match body
-    [`(=> ,conds ... ,post)
-     (define conds*
-       (filter (λ (x) (not (equal? x 'true)))
-               (map (curryr massage-body ctx dom) conds)))
-     (cond
-      [(set-member? conds* 'false) 'true]
-      [(null? conds*) (massage-body post ctx dom)]
-      [else `(=> ,@conds* ,(massage-body post ctx dom))])]
-    [`(or ,bits ...)
-     (apply smt-or (map (curryr massage-body ctx dom) bits))]
-    [`(= ,(? (curry dict-has-key? ctx) b)
-         ,(app ~a (regexp #rx"^box([0-9]+)$" (list bname _))))
-     (define rec (dict-ref ctx b))
-     (if (equal? (~a (dump-box rec)) bname) 'true 'false)]
-    [`(is-component ,(? (curry dict-has-key? ctx) b))
-     (if (is-component (dict-ref ctx b)) 'true 'false)]
-    [_ body]))
 
 (define (layout-constraints dom emit elt)
   (define cns

--- a/src/modularize.rkt
+++ b/src/modularize.rkt
@@ -1,7 +1,10 @@
 #lang racket
 
 (require "common.rkt" "tree.rkt" "dom.rkt" "smt.rkt" "prune.rkt")
-(provide modularize)
+(provide modularize is-component)
+
+(define (is-component box)
+  (or (not (node-parent box)) (node-get* box ':split)))
 
 (define (split-document doc)
   (define out (make-hash))

--- a/src/selectors.rkt
+++ b/src/selectors.rkt
@@ -3,7 +3,7 @@
 (require "common.rkt" "tree.rkt" "spec/css-properties.rkt" "spec/media-query.rkt")
 (module+ test (require rackunit))
 (provide equivalence-classes selector-matches?
-         rule-matchlist (struct-out rulematch))
+         rule-matchlist (struct-out rulematch) rule-allows-property?)
 
 
 
@@ -29,6 +29,13 @@
 
 (define-by-match partial-rule?
   (list (? selector?) (? attribute?) ... (or (list (? property?) _ (? attribute?) ...) '?) ...))
+
+(define/contract (rule-allows-property? rule prop)
+  (-> partial-rule? property? boolean?)
+  (match-define (list selector (? attribute? attrs) ... (and (or (? list?) '?) props) ...) rule)
+  (or (set-member? props '?)
+      (and (dict-has-key? props prop)
+           (not (null? (dict-ref props prop))))))
 
 (define/contract (selector-matches? sel elt)
   (-> selector? node? boolean?)

--- a/src/selectors.rkt
+++ b/src/selectors.rkt
@@ -185,8 +185,8 @@
   (match-define (list (? selector? selector) (? attribute? attrs) ...
                       (list (? property? properties) values (? attribute? propattrs) ...) ...) rule)
   (define-values (important unimportant)
-    (partition (λ (x) (set-member? (third x) ':important))
-               (map list properties values propattrs)))
+    (partition (λ (x) (set-member? (cddr x) ':important))
+               (map list* properties values propattrs)))
   (list
    (if (null? important) #f `(,selector ,@attrs ,@important))
    (if (null? unimportant) #f `(,selector ,@attrs ,@unimportant))))

--- a/src/verify.rkt
+++ b/src/verify.rkt
@@ -1,0 +1,123 @@
+#lang racket
+(require racket/hash)
+(require "common.rkt" "dom.rkt" "smt.rkt" "encode.rkt" "tree.rkt" "selectors.rkt" "modularize.rkt")
+(require "spec/css-properties.rkt" "spec/tree.rkt" "spec/compute-style.rkt" "spec/layout.rkt"
+         "spec/percentages.rkt" "spec/utils.rkt" "spec/float.rkt" "spec/colors.rkt" "spec/fonts.rkt"
+         "spec/media-query.rkt" "assertions.rkt" "spec/replaced-elements.rkt")
+(provide add-test model-valid/z3 model-valid?)
+
+;; Is the model valid?
+
+(define (model-valid/z3 doms)
+  (apply smt-and
+         (for*/list ([dom doms] [box (in-boxes dom)])
+           `(ez.sufficient ,(dump-box box)))))
+
+(define (model-valid? doms m)
+  (define out
+    (for*/and ([dom doms] [box (in-boxes dom)])
+      (extract-field m box 'ez.sufficient)))
+  (when (for*/or ([dom doms] [box (in-boxes dom)])
+          (extract-field m box 'ez.lookback))
+     (warn "Ignoring the exclusion zome assumptions"))
+  out)
+
+(define (add-test doms tests #:component [component #f] #:render? [render? true])
+  (match-define (list dom) doms)
+  (define possible-boxes
+    (if component
+        (nodes-below component  '(:pre :spec :assert :admit))
+        (for/list ([box (in-boxes dom)]) box)))
+  `((declare-const which-constraint Real)
+    ,@(for/reap [sow] ([test tests] [id (in-naturals)]
+                       #:when true
+                       [(var cexvar) (in-dict (car test))])
+        (define var-values
+          (or (not-true-inputs (cdr test) (list var) dom)
+              (map dump-box possible-boxes)))
+        (sow `(declare-const ,cexvar Box))
+        (sow `(assert ,(apply smt-or (for/list ([boxvar var-values]) `(= ,cexvar ,boxvar))))))
+    (assert ,(apply smt-or
+                    (for/list ([test tests] [i (in-naturals)])
+                      `(and (not ,(cdr test)) (= which-constraint ,i)))))
+    ,@(reap [sow]
+         (for ([box (in-boxes dom)])
+           (spec-constraints (if render? '(:spec) '(:spec :assert :admit)) dom sow box)))))
+
+(define (nodes-below node stop?)
+  (reap [sow]
+        (let loop ([node node])
+          (sow node)
+          (for ([child (node-children node)])
+            (if (stop? child)
+                (sow child)
+                (loop child))))))
+
+(define (get-node-names nodes)
+  (for/hash ([node nodes] #:when (node-get node ':name #:default false))
+    (values (node-get node ':name) (dump-box node))))
+
+(define (my-set-intersect . as)
+  (foldl (λ (set acc) (if set (if acc (set-intersect set acc) set) acc)) #f as))
+
+(define (my-set-union . as)
+  (foldl (λ (set acc) (if set (if acc (set-union set acc) #f) #f)) '() as))
+
+(define (not-true-inputs body ctx dom)
+  (match body
+    [`(=> ,conds ... ,post)
+     (apply my-set-union (not-true-inputs post ctx dom)
+            (map (curryr not-false-inputs ctx dom) conds))]
+    [`(and ,bits ...)
+     (apply my-set-union (map (curryr not-true-inputs ctx dom) bits))]
+    [_ '()]))
+
+(define (not-false-inputs body ctx dom)
+  (match body
+    [`(or ,bits ...)
+     (apply my-set-union (map (curryr not-false-inputs ctx dom) bits))]
+    [`(= ,(? (curry set-member? ctx) b)
+         ,(app ~a (regexp #rx"^box([0-9]+)$" (list bname _))))
+     (list (cons b bname))]
+    [_ #f]))
+
+(define (massage-body body ctx dom)
+  (match body
+    [`(=> ,conds ... ,post)
+     (define conds*
+       (filter (λ (x) (not (equal? x 'true)))
+               (map (curryr massage-body ctx dom) conds)))
+     (cond
+      [(set-member? conds* 'false) 'true]
+      [(null? conds*) (massage-body post ctx dom)]
+      [else `(=> ,@conds* ,(massage-body post ctx dom))])]
+    [`(or ,bits ...)
+     (apply smt-or (map (curryr massage-body ctx dom) bits))]
+    [`(= ,(? (curry dict-has-key? ctx) b)
+         ,(app ~a (regexp #rx"^box([0-9]+)$" (list bname _))))
+     (define rec (dict-ref ctx b))
+     (if (equal? (~a (dump-box rec)) bname) 'true 'false)]
+    [`(is-component ,(? (curry dict-has-key? ctx) b))
+     (if (is-component (dict-ref ctx b)) 'true 'false)]
+    [_ body]))
+
+(define (spec-constraints fields dom emit box)
+  (when (ormap (curry node-get* box) fields)
+    (define nodes (nodes-below box (λ (x) (ormap (curry node-get* x) fields))))
+    (define pres (node-get* box ':pre #:default '()))
+
+    (for ([field fields] #:when (node-get* box field) [test (node-get* box field)] [i (in-naturals)])
+      (define-values (vars body) (disassemble-forall test))
+
+      (define ctx
+        (hash-union
+         (for/hash ([var vars]) (values var var))
+         (hash '? (dump-box box))
+         (get-node-names nodes)))
+      (define spec (compile-assertion (list dom) `(=> ,@pres ,body) ctx))
+
+      (for ([vals (apply cartesian-product (map (const nodes) vars))] [j (in-naturals)])
+        (define body* (massage-body spec (map cons vars vals) dom))
+        (unless (equal? body* 'true)
+          (emit `(assert (let ,(map (λ (v x) (list v (dump-box x))) vars vals) ,body*))))))))
+


### PR DESCRIPTION
`main.rkt` was once the entry point to Cassius. Nowadays it is not; `frontend` and then `run` sit before it.  But the legacy lives on in the large number of random things stuffed into `main.rkt`. This PR:

- Moves the `extract-*` methods to `encode.rkt` where their friends live
- Moves `model-sufficiency` and `add-test` to the new `verify.rkt`
- Moves `is-component` to `modularize.rkt`
- Moves `rule-applies-property?` to `selectors.rkt`

It also changes up how we compile Typescript to make it a little less hacky (but still mildy hacky).