### PR TITLE
Add the ability to erase extranious elements like text from items inside a list

### DIFF
--- a/bench/button_test_stress/button_test_stress.html
+++ b/bench/button_test_stress/button_test_stress.html
@@ -1,0 +1,9 @@
+  <html>
+  <body>
+  	<ul id="list">
+  	</ul>
+  	<script type="text/javascript" src="list_append.js">
+  	</script>
+  	<button type="button" id="add" onclick="add_element()">Click Me! </button>
+  </body>
+  </html>

--- a/bench/button_test_stress/list_append.js
+++ b/bench/button_test_stress/list_append.js
@@ -1,0 +1,7 @@
+function add_element(){
+  	var list = document.getElementById("list");
+  	let list_element = document.createElement('li');
+  	list.appendChild(list_element);
+  	list_element.id = 'element-' + list.getElementsByTagName("li").length;
+	list_element.innerHTML = "value-" + list.getElementsByTagName("li").length;
+}

--- a/bench/button_test_stress/prerun.js
+++ b/bench/button_test_stress/prerun.js
@@ -1,0 +1,5 @@
+click_event = new CustomEvent('click');
+add = document.querySelector('#add');
+for(i=0; i<50; i++) {
+  add.dispatchEvent(click_event);
+}

--- a/bench/list_all.proof
+++ b/bench/list_all.proof
@@ -29,7 +29,7 @@
 (proof (interactive-onscreen interactive-onscreen zero-presses one-press two-presses three-presses)
         (component list (id list))
 	(component button (tag button))
-	(components (child (id list) *))
+	(components todos (child (id list) *))
         (erase list :w)
         (erase list :text)
 

--- a/bench/list_all.proof
+++ b/bench/list_all.proof
@@ -29,7 +29,7 @@
 (proof (interactive-onscreen interactive-onscreen zero-presses one-press two-presses three-presses)
         (component list (id list))
 	(component button (tag button))
-	(components todos (child (id list) *))
+	(components (child (id list) *))
         (erase list :w)
         (erase list :text)
 

--- a/bench/list_all.proof
+++ b/bench/list_all.proof
@@ -29,9 +29,8 @@
 (proof (interactive-onscreen interactive-onscreen zero-presses one-press two-presses three-presses)
         (component list (id list))
 	(component button (tag button))
-	(components (child (id list) *))
-        (erase list :w)
-        (erase list :text)
+	(components todos (child (id list) *))
+        (erase todos :text)
 
         (assert list 
           (=> (or (= (prev list) null)

--- a/bench/stress_test.proof
+++ b/bench/stress_test.proof
@@ -1,0 +1,26 @@
+;;A Proof to verify the functionality of a simple website that uses java script
+;;Skyler Griffith
+(import "common.thm")
+
+(page stress (load "stress_test.rkt" button_test_stress)
+        :w (between 800 1920)
+        :h (between 600 1280)
+        :fs (between 16 32)
+)
+ 
+
+(proof (interactive-onscreen interactive-onscreen stress)
+        (component list (id list))
+	(components todos (child (id list) *))
+;;        (erase todos :text)
+
+        (assert list 
+          (=> (or (= (prev list) null)
+                  (non-negative-margins (prev list)))
+              (non-negative-margins list)))
+	(assert *
+	(forall(b) (=> (onscreen ?)
+			 (=> (or (is-component b) (is-interactive b)) (onscreen b)))))
+	(assert (- * list) (forall (t) (=> (has-type t text) (> (width t) 0) (non-negative-margins ?))))
+	(assert root (onscreen root))
+)

--- a/src/frontend.rkt
+++ b/src/frontend.rkt
@@ -107,8 +107,15 @@
     [`((random ,n))
      (parse-check-result doms tests (test-problem problem #:samples n))]))
 
-(define (solve-problem problem)
+(define (rename-dom doc)
+  (struct-copy dom doc [name 'removed-for-caching]))
+
+(define (remove-for-caching problem)
   (define problem* (dict-set problem ':name '("[removed for caching]")))
+  (dict-update problem* ':documents (curry map rename-dom)))
+
+(define (solve-problem problem)
+  (define problem* (remove-for-caching problem))
 
   (cond
    [(*cache-file*)
@@ -120,7 +127,7 @@
        [else
         (solve-problem* problem*)]))
     (unless (match out [(list 'error _) true] ['break true] [_ false])
-      (hash-set! *cache* problem out)
+      (hash-set! *cache* problem* out)
       (call-with-output-file (*cache-file*) #:exists 'replace (λ (p) (write *cache* p))))
     out]
    [else

--- a/src/frontend.rkt
+++ b/src/frontend.rkt
@@ -2,7 +2,7 @@
 (require racket/hash)
 (require "common.rkt" "z3.rkt" "dom.rkt" "tree.rkt" "solver.rkt" "encode.rkt" "smt.rkt")
 (require "main.rkt" "spec/float.rkt")
-(require "assertions.rkt" "verify.rkt" "assertion2js.rkt" "prune.rkt")
+(require "assertions.rkt" "verify.rkt" "assertion2js.rkt")
 (provide (struct-out success) (struct-out failure) solve-problem *exit-early*)
 
 (define *exit-early* (make-parameter void))
@@ -107,8 +107,15 @@
     [`((random ,n))
      (parse-check-result doms tests (test-problem problem #:samples n))]))
 
+(define (rename-dom doc)
+  (struct-copy dom doc [name 'removed-for-caching]))
+
+(define (remove-for-caching problem)
+  (define problem* (dict-set problem ':name '("[removed for caching]")))
+  (dict-update problem* ':documents (curry map rename-dom)))
+
 (define (solve-problem problem)
-  (define problem* (prune-for-caching problem))
+  (define problem* (remove-for-caching problem))
 
   (cond
    [(*cache-file*)

--- a/src/frontend.rkt
+++ b/src/frontend.rkt
@@ -108,18 +108,20 @@
      (parse-check-result doms tests (test-problem problem #:samples n))]))
 
 (define (solve-problem problem)
+  (define problem* (dict-set problem ':name '("[removed for caching]")))
+
   (cond
    [(*cache-file*)
     (define out
       (cond
-       [(hash-has-key? *cache* problem)
+       [(hash-has-key? *cache* problem*)
         ((make-log) "Retrieved result from cache")
-        (hash-ref *cache* problem)]
+        (hash-ref *cache* problem*)]
        [else
-        (solve-problem* problem)]))
+        (solve-problem* problem*)]))
     (unless (match out [(list 'error _) true] ['break true] [_ false])
       (hash-set! *cache* problem out)
       (call-with-output-file (*cache-file*) #:exists 'replace (λ (p) (write *cache* p))))
     out]
    [else
-    (solve-problem* problem)]))
+    (solve-problem* problem*)]))

--- a/src/frontend.rkt
+++ b/src/frontend.rkt
@@ -2,7 +2,7 @@
 (require racket/hash)
 (require "common.rkt" "z3.rkt" "dom.rkt" "tree.rkt" "solver.rkt" "encode.rkt" "smt.rkt")
 (require "main.rkt" "spec/float.rkt")
-(require "assertions.rkt" "verify.rkt" "assertion2js.rkt")
+(require "assertions.rkt" "verify.rkt" "assertion2js.rkt" "prune.rkt")
 (provide (struct-out success) (struct-out failure) solve-problem *exit-early*)
 
 (define *exit-early* (make-parameter void))
@@ -107,15 +107,8 @@
     [`((random ,n))
      (parse-check-result doms tests (test-problem problem #:samples n))]))
 
-(define (rename-dom doc)
-  (struct-copy dom doc [name 'removed-for-caching]))
-
-(define (remove-for-caching problem)
-  (define problem* (dict-set problem ':name '("[removed for caching]")))
-  (dict-update problem* ':documents (curry map rename-dom)))
-
 (define (solve-problem problem)
-  (define problem* (remove-for-caching problem))
+  (define problem* (prune-for-caching problem))
 
   (cond
    [(*cache-file*)

--- a/src/modularize.rkt
+++ b/src/modularize.rkt
@@ -45,11 +45,19 @@
   (for*/list ([doc (dict-ref problem ':documents)] [(name thing) (split-document doc)]
               #:unless (null? (cdr thing)))
     (match-define (cons piece specs) thing)
-    (define problem*
-      (dict-set* problem
-                 ':documents (list piece)
-                 ':name (list (dom-name piece))
-                 ':tests specs
-                 ':tool '(assert)))
-    (for/fold ([problem problem*]) ([pruning-function pruning-functions])
-      (pruning-function problem))))
+    (define elements* (prune-elements (dom-boxes piece) (dom-elements piece)))
+    (define sheets* (prune-sheets sheets (list elements*)))
+    (define elements** (prune-attrs elements* sheets* specs))
+    (define fonts* (prune-fonts fonts sheets*))
+    (define-values (boxes* elements***) (prune-renumber (dom-boxes piece) elements**))
+    (define boxes** (prune-box-attrs boxes*))
+    (dict-set* problem
+               ':documents (list (struct-copy dom piece [elements elements***] [boxes boxes**]))
+               ':name (list (dom-name piece)) 
+               ':tests specs
+               ':tool '(assert)
+               ':sheets sheets*
+               ':fonts fonts*
+               ':title '("[removed for caching]")
+               ':url '("[removed for caching]")
+               ':features '())))

--- a/src/modularize.rkt
+++ b/src/modularize.rkt
@@ -45,19 +45,11 @@
   (for*/list ([doc (dict-ref problem ':documents)] [(name thing) (split-document doc)]
               #:unless (null? (cdr thing)))
     (match-define (cons piece specs) thing)
-    (define elements* (prune-elements (dom-boxes piece) (dom-elements piece)))
-    (define sheets* (prune-sheets sheets (list elements*)))
-    (define elements** (prune-attrs elements* sheets* specs))
-    (define fonts* (prune-fonts fonts sheets*))
-    (define-values (boxes* elements***) (prune-renumber (dom-boxes piece) elements**))
-    (define boxes** (prune-box-attrs boxes*))
-    (dict-set* problem
-               ':documents (list (struct-copy dom piece [elements elements***] [boxes boxes**]))
-               ':name (list (dom-name piece)) 
-               ':tests specs
-               ':tool '(assert)
-               ':sheets sheets*
-               ':fonts fonts*
-               ':title '("[removed for caching]")
-               ':url '("[removed for caching]")
-               ':features '())))
+    (define problem*
+      (dict-set* problem
+                 ':documents (list piece)
+                 ':name (list (dom-name piece))
+                 ':tests specs
+                 ':tool '(assert)))
+    (for/fold ([problem problem*]) ([pruning-function pruning-functions])
+      (pruning-function problem))))

--- a/src/modularize.rkt
+++ b/src/modularize.rkt
@@ -50,13 +50,15 @@
     (define elements** (prune-attrs elements* sheets* specs))
     (define fonts* (prune-fonts fonts sheets*))
     (define-values (boxes* elements***) (prune-renumber (dom-boxes piece) elements**))
+    (define boxes** (prune-box-attrs boxes*))
     (dict-set* problem
-               ':documents (list (struct-copy dom piece [elements elements***] [boxes boxes*]))
-               ':name (list (dom-name piece))
+               ':documents (list (struct-copy dom piece [elements elements***] [boxes boxes**]))
+               ':name (list (dom-name piece)) 
                ':tests specs
                ':tool '(assert)
                ':sheets sheets*
                ':fonts fonts*
                ':title '("[removed for caching]")
                ':url '("[removed for caching]")
-               ':features '())))
+               ':features '()))
+    (dict-set* dom 'name "replaced-for-caching"))

--- a/src/modularize.rkt
+++ b/src/modularize.rkt
@@ -60,5 +60,4 @@
                ':fonts fonts*
                ':title '("[removed for caching]")
                ':url '("[removed for caching]")
-               ':features '()))
-    (dict-set* dom 'name "replaced-for-caching"))
+               ':features '())))

--- a/src/proofs.rkt
+++ b/src/proofs.rkt
@@ -66,18 +66,12 @@
        (set! selectors (cons sel selectors))
        (hash-set! named-selectors name sel)
        (set! components (cons box components))]
-    [`(components ,sel)
-       (define selected-boxes (get-by-selector sel))
+      [`(components ,sels ...)
+       (define selected-boxes (append-map get-by-selector sels))
        (for ([box selected-boxes])
          (node-set*! box ':spec (list))
          (node-set! box ':split (length components))
-         (set! components (cons box components)))]
-      [`(components ,name ,sel)
-       (define selected-boxes (get-by-selector sel))
-       (for ([box selected-boxes])
-         (node-set! box ':name name)
-         (node-set*! box ':spec (list))
-         (node-set! box ':split (length components))
+         (set! selectors (append sels selectors))
          (set! components (cons box components)))]
 
       ;;Given a name and type of value this command erases all values of that type from the component with the given name

--- a/src/proofs.rkt
+++ b/src/proofs.rkt
@@ -66,12 +66,18 @@
        (set! selectors (cons sel selectors))
        (hash-set! named-selectors name sel)
        (set! components (cons box components))]
-      [`(components ,sels ...)
-       (define selected-boxes (append-map get-by-selector sels))
+      [`(components ,sel)
+       (define selected-boxes (get-by-selector sel))
        (for ([box selected-boxes])
          (node-set*! box ':spec (list))
          (node-set! box ':split (length components))
-         (set! selectors (append sels selectors))
+         (set! components (cons box components)))]
+      [`(components ,name ,sel)
+       (define selected-boxes (get-by-selector sel))
+       (hash-set! box-context name selected-boxes)
+       (for ([box selected-boxes])
+         (node-set*! box ':spec (list))
+         (node-set! box ':split (length components))
          (set! components (cons box components)))]
 
       ;;Given a name and type of value this command erases all values of that type from the component with the given name

--- a/src/proofs.rkt
+++ b/src/proofs.rkt
@@ -66,12 +66,18 @@
        (set! selectors (cons sel selectors))
        (hash-set! named-selectors name sel)
        (set! components (cons box components))]
-      [`(components ,sels ...)
-       (define selected-boxes (append-map get-by-selector sels))
+    [`(components ,sel)
+       (define selected-boxes (get-by-selector sel))
        (for ([box selected-boxes])
          (node-set*! box ':spec (list))
          (node-set! box ':split (length components))
-         (set! selectors (append sels selectors))
+         (set! components (cons box components)))]
+      [`(components ,name ,sel)
+       (define selected-boxes (get-by-selector sel))
+       (for ([box selected-boxes])
+         (node-set! box ':name name)
+         (node-set*! box ':spec (list))
+         (node-set! box ':split (length components))
          (set! components (cons box components)))]
 
       ;;Given a name and type of value this command erases all values of that type from the component with the given name

--- a/src/proofs.rkt
+++ b/src/proofs.rkt
@@ -9,7 +9,7 @@
   (define-values (vars body) (disassemble-forall assert))
   (if (null? vars) ':spec ':assert))
 
-(define (box-set stx components ctx)
+(define (box-set stx ctx)
   (let loop ([stx stx])
     (match stx
       [(? symbol?) (dict-ref ctx stx)]
@@ -81,13 +81,13 @@
 
       ;;Given a name and type of value this command erases all values of that type from the component with the given name
       [`(erase ,name ,type)
-       (define boxes (box-set name (hash-ref box-context '*) box-context))
+       (define boxes (box-set name box-context))
        (for* ([box (in-list boxes)] [subbox (in-tree box)])
          (node-remove! subbox type))]
 
       [`(,(and (or 'assert 'page (list 'random (? number?))
                    'exhaustive 'admit) tool) ,boxes ,assert)
-	(define foo (box-set boxes (hash-ref box-context '*) box-context))
+	(define foo (box-set boxes box-context))
        (for ([box foo])
          (if (equal? tool 'assert)
              (node-add! box (spec-or-assert assert) assert)
@@ -96,7 +96,7 @@
                (set! extra-problems
                      (cons (list tool box assert) extra-problems)))))]
       [`(pre ,boxes ,assert)
-       (for ([box (box-set boxes (hash-ref box-context '*) box-context)])
+       (for ([box (box-set boxes box-context)])
          (node-add! box ':pre assert))]
       [`(lemma (,thm ,boxes ...))
        (define-values (vars body) (disassemble-forall (theorems thm)))       

--- a/src/prune.rkt
+++ b/src/prune.rkt
@@ -1,7 +1,7 @@
 #lang racket
 
 (require "common.rkt" "tree.rkt" "dom.rkt" "smt.rkt" "selectors.rkt" "assertions.rkt")
-(provide prune-elements prune-sheets prune-attrs prune-fonts prune-renumber)
+(provide prune-elements prune-sheets prune-attrs prune-fonts prune-box-attrs prune-renumber)
 
 (define/contract (prune-elements box-stx elts-stx) ; TODO: kind of weird here with the unparsing
   (-> node-stx? node-stx? node-stx?)
@@ -71,12 +71,19 @@
   (define used-classes (apply set-union used-classes*))
   (define used-ids (apply set-union used-ids*))
   (for ([elt (in-tree elts)])
+    (node-remove! elt ':split)
     (define old-classes (node-get elt ':class #:default '()))
     (node-set! elt ':class (set-intersect old-classes used-classes))
     (define old-id (node-get elt ':id))
     (when (and old-id (not (set-member? used-ids old-id)))
       (node-remove! elt ':id)))
   (unparse-tree elts))
+
+(define (prune-box-attrs box-stx)
+  (define boxes (parse-tree box-stx))
+  (for ([box (in-tree boxes)])
+    (node-remove! box ':split))
+  (unparse-tree boxes))
 
 (define (prune-renumber boxes-stx elts-stx)
   (define boxes (parse-tree boxes-stx))

--- a/src/prune.rkt
+++ b/src/prune.rkt
@@ -96,7 +96,7 @@
 
 (define (prune-fonts problem)
   (define fonts (dict-ref problem ':fonts))
-  (define sheets (dict-ref problem ':fonts))
+  (define sheets (dict-ref problem ':sheets))
   (define-values (families weights styles)
     (reap [f! w! s!]
       (f! "serif")
@@ -111,13 +111,13 @@
             ['font-style (s! val)]
             [_ (void)])))))
   (define fonts*
-    (for/reap [reap] ([font fonts])
+    (for/reap [sow] ([font fonts])
       (match-define (list size family weight style metrics ...) font)
       (when (and (set-member? families family)
                  (set-member? weights weight)
                  (set-member? styles style))
-        font)))
-  (dict-ref problem ':fonts fonts*))
+        (sow font))))
+  (dict-set problem ':fonts fonts*))
 
 (define (prune-renumber problem)
   (define doc (first (dict-ref problem ':documents)))

--- a/src/prune.rkt
+++ b/src/prune.rkt
@@ -1,11 +1,12 @@
 #lang racket
 
 (require "common.rkt" "tree.rkt" "dom.rkt" "smt.rkt" "selectors.rkt" "assertions.rkt")
-(provide prune-elements prune-sheets prune-attrs prune-fonts prune-box-attrs prune-renumber)
+(provide pruning-functions prune-for-caching)
 
-(define/contract (prune-elements box-stx elts-stx) ; TODO: kind of weird here with the unparsing
-  (-> node-stx? node-stx? node-stx?)
-  (define boxes (parse-tree box-stx))
+(define (prune-elements problem) ; TODO: kind of weird here with the unparsing
+  (define doc (first (dict-ref problem ':documents)))
+  (define elts-stx (dom-elements doc))
+  (define boxes (parse-tree (dom-boxes doc)))
   (define used-ids
     (for/set ([box (in-tree boxes)] #:when (node-get* box ':elt #:default false))
       (node-get box ':elt)))
@@ -24,16 +25,19 @@
                          (for/list ([(ids child) (in-dict child-res)]
                                             #:unless (set-empty? (set-intersect ids used-ids)))
                                    child)))))
-  node)
+  (dict-set problem ':documents (list (struct-copy dom doc [elements node]))))
 
-(define (prune-sheets sheets elements-stxs)
-  (define elementss (map parse-tree elements-stxs))
-  (for/list ([sheet sheets])
-    (for/list ([rule sheet]
-               [i (in-naturals)]
-               #:when (for*/or ([elements elementss] [elt (in-tree elements)])
-                        (selector-matches? (car rule) elt)))
-      rule)))
+(define (prune-sheets problem)
+  (define sheets (dict-ref problem ':sheets))
+  (define elementss (map (compose parse-tree dom-elements) (dict-ref problem ':documents)))
+  (define sheets*
+    (for/list ([sheet sheets])
+      (for/list ([rule sheet]
+                 [i (in-naturals)]
+                 #:when (for*/or ([elements elementss] [elt (in-tree elements)])
+                          (selector-matches? (car rule) elt)))
+        rule)))
+  (dict-set problem ':sheets sheets*))
 
 (define (classes-ids-used selector)
   (reap [class! id!]
@@ -58,8 +62,12 @@
      (append-map selectors-in-test args)]
     [_ '()]))
 
-(define (prune-attrs elts-stx sheets tests)
-  (define elts (parse-tree elts-stx))
+(define (prune-attrs problem)
+  (define tests (dict-ref problem ':tests))
+  (define sheets (dict-ref problem ':sheets))
+  (define doc (first (dict-ref problem ':documents)))
+  (define elts (parse-tree (dom-elements doc)))
+
   (define asserts
     (append
      tests
@@ -77,25 +85,18 @@
     (define old-id (node-get elt ':id))
     (when (and old-id (not (set-member? used-ids old-id)))
       (node-remove! elt ':id)))
-  (unparse-tree elts))
+  (dict-set problem ':documents (list (struct-copy dom doc [elements (unparse-tree elts)]))))
 
-(define (prune-box-attrs box-stx)
-  (define boxes (parse-tree box-stx))
+(define (prune-box-attrs problem)
+  (define doc (first (dict-ref problem ':documents)))
+  (define boxes (parse-tree (dom-boxes doc)))
   (for ([box (in-tree boxes)])
     (node-remove! box ':split))
-  (unparse-tree boxes))
+  (dict-set problem ':documents (list (struct-copy dom doc [boxes (unparse-tree boxes)]))))
 
-(define (prune-renumber boxes-stx elts-stx)
-  (define boxes (parse-tree boxes-stx))
-  (define elts (parse-tree elts-stx))
-  (define mapping (make-hash))
-  (for ([box (in-tree boxes)] #:when (node-get box ':elt))
-    (node-set! box ':elt (hash-ref! mapping (node-get box ':elt) (hash-count mapping))))
-  (for ([elt (in-tree elts)] #:when (node-get elt ':num))
-    (node-set! elt ':num (hash-ref! mapping (node-get elt ':num) (hash-count mapping))))
-  (values (unparse-tree boxes) (unparse-tree elts)))
-
-(define (prune-fonts fonts sheets)
+(define (prune-fonts problem)
+  (define fonts (dict-ref problem ':fonts))
+  (define sheets (dict-ref problem ':fonts))
   (define-values (families weights styles)
     (reap [f! w! s!]
       (f! "serif")
@@ -109,11 +110,43 @@
             ['font-weight (w! val)]
             ['font-style (s! val)]
             [_ (void)])))))
-  (filter
-   identity
-   (for/list ([font fonts])
-     (match-define (list size family weight style metrics ...) font)
-     (if (and (set-member? families family) (set-member? weights weight) (set-member? styles style))
-         font
-         #f))))
+  (define fonts*
+    (for/reap [reap] ([font fonts])
+      (match-define (list size family weight style metrics ...) font)
+      (when (and (set-member? families family)
+                 (set-member? weights weight)
+                 (set-member? styles style))
+        font)))
+  (dict-ref problem ':fonts fonts*))
 
+(define (prune-renumber problem)
+  (define doc (first (dict-ref problem ':documents)))
+  (define elts (parse-tree (dom-elements doc)))
+  (define boxes (parse-tree (dom-boxes doc)))
+
+  (define mapping (make-hash))
+  (for ([box (in-tree boxes)] #:when (node-get box ':elt))
+    (node-set! box ':elt (hash-ref! mapping (node-get box ':elt) (hash-count mapping))))
+  (for ([elt (in-tree elts)] #:when (node-get elt ':num))
+    (node-set! elt ':num (hash-ref! mapping (node-get elt ':num) (hash-count mapping))))
+
+  (dict-set problem ':documents
+            (list (struct-copy dom doc [elements (unparse-tree elts)]
+                               [boxes (unparse-tree boxes)]))))
+
+(define pruning-functions
+  (list prune-elements
+        prune-sheets
+        prune-attrs
+        prune-fonts
+        prune-renumber
+        prune-box-attrs))
+
+(define (prune-for-caching problem)
+  (define doc (first (dict-ref problem ':documents)))
+  (dict-set* problem
+             ':name '("[removed for caching]")
+             ':title '("[removed for caching]")
+             ':url '("[removed for caching]")
+             ':documents (list (struct-copy dom doc [name 'removed-for-caching]))
+             ':features '()))


### PR DESCRIPTION
The goal is to prove facts about, for example, a page with a list of any length. So far, I've implemented the `erase` tactic which erases certain properties (like `:w` from text nodes), which can make multiple list items look the same.

- [x] Add `erase` tactic
- [x] Fix caching by eliminating names
- [x] Actually eliminate names elsewhere so that output looks reasonable
- [x] Alter the components tactic to allow a name to be attached to the list of components
- [x] Alter erase to be able to erase every item included in a list created by components