### PR TITLE
Changed pruning functions to all accept & return a problem

### DIFF
--- a/src/frontend.rkt
+++ b/src/frontend.rkt
@@ -2,7 +2,7 @@
 (require racket/hash)
 (require "common.rkt" "z3.rkt" "dom.rkt" "tree.rkt" "solver.rkt" "encode.rkt" "smt.rkt")
 (require "main.rkt" "spec/float.rkt")
-(require "assertions.rkt" "verify.rkt" "assertion2js.rkt")
+(require "assertions.rkt" "verify.rkt" "assertion2js.rkt" "prune.rkt")
 (provide (struct-out success) (struct-out failure) solve-problem *exit-early*)
 
 (define *exit-early* (make-parameter void))
@@ -107,15 +107,8 @@
     [`((random ,n))
      (parse-check-result doms tests (test-problem problem #:samples n))]))
 
-(define (rename-dom doc)
-  (struct-copy dom doc [name 'removed-for-caching]))
-
-(define (remove-for-caching problem)
-  (define problem* (dict-set problem ':name '("[removed for caching]")))
-  (dict-update problem* ':documents (curry map rename-dom)))
-
 (define (solve-problem problem)
-  (define problem* (remove-for-caching problem))
+  (define problem* (prune-for-caching problem))
 
   (cond
    [(*cache-file*)

--- a/src/modularize.rkt
+++ b/src/modularize.rkt
@@ -45,19 +45,11 @@
   (for*/list ([doc (dict-ref problem ':documents)] [(name thing) (split-document doc)]
               #:unless (null? (cdr thing)))
     (match-define (cons piece specs) thing)
-    (define elements* (prune-elements (dom-boxes piece) (dom-elements piece)))
-    (define sheets* (prune-sheets sheets (list elements*)))
-    (define elements** (prune-attrs elements* sheets* specs))
-    (define fonts* (prune-fonts fonts sheets*))
-    (define-values (boxes* elements***) (prune-renumber (dom-boxes piece) elements**))
-    (define boxes** (prune-box-attrs boxes*))
-    (dict-set* problem
-               ':documents (list (struct-copy dom piece [elements elements***] [boxes boxes**]))
-               ':name (list (dom-name piece)) 
-               ':tests specs
-               ':tool '(assert)
-               ':sheets sheets*
-               ':fonts fonts*
-               ':title '("[removed for caching]")
-               ':url '("[removed for caching]")
-               ':features '())))
+    (define problem*
+      (dict-set* problem
+                 ':documents (list piece)
+                 ':name (list (dom-name piece))
+                 ':tests specs
+                 ':tool '(assert)))
+    (for/fold ([problem problem*]) ([pruning-function pruning-functions])
+      (pruning-function problem))))

--- a/src/prune.rkt
+++ b/src/prune.rkt
@@ -3,8 +3,7 @@
 (require "common.rkt" "tree.rkt" "dom.rkt" "smt.rkt" "selectors.rkt" "assertions.rkt")
 (provide pruning-functions prune-for-caching)
 
-(define/contract (prune-elements problem) ; TODO: kind of weird here with the unparsing
-  (-> node-stx? node-stx? node-stx?)
+(define (prune-elements problem) ; TODO: kind of weird here with the unparsing
   (define doc (first (dict-ref problem ':documents)))
   (define elts-stx (dom-elements doc))
   (define boxes (parse-tree (dom-boxes doc)))

--- a/src/prune.rkt
+++ b/src/prune.rkt
@@ -1,11 +1,13 @@
 #lang racket
 
 (require "common.rkt" "tree.rkt" "dom.rkt" "smt.rkt" "selectors.rkt" "assertions.rkt")
-(provide prune-elements prune-sheets prune-attrs prune-fonts prune-box-attrs prune-renumber)
+(provide pruning-functions prune-for-caching)
 
-(define/contract (prune-elements box-stx elts-stx) ; TODO: kind of weird here with the unparsing
+(define/contract (prune-elements problem) ; TODO: kind of weird here with the unparsing
   (-> node-stx? node-stx? node-stx?)
-  (define boxes (parse-tree box-stx))
+  (define doc (first (dict-ref problem ':documents)))
+  (define elts-stx (dom-elements doc))
+  (define boxes (parse-tree (dom-boxes doc)))
   (define used-ids
     (for/set ([box (in-tree boxes)] #:when (node-get* box ':elt #:default false))
       (node-get box ':elt)))
@@ -24,16 +26,19 @@
                          (for/list ([(ids child) (in-dict child-res)]
                                             #:unless (set-empty? (set-intersect ids used-ids)))
                                    child)))))
-  node)
+  (dict-set problem ':documents (list (struct-copy dom doc [elements node]))))
 
-(define (prune-sheets sheets elements-stxs)
-  (define elementss (map parse-tree elements-stxs))
-  (for/list ([sheet sheets])
-    (for/list ([rule sheet]
-               [i (in-naturals)]
-               #:when (for*/or ([elements elementss] [elt (in-tree elements)])
-                        (selector-matches? (car rule) elt)))
-      rule)))
+(define (prune-sheets problem)
+  (define sheets (dict-ref problem ':sheets))
+  (define elementss (map (compose parse-tree dom-elements) (dict-ref problem ':documents)))
+  (define sheets*
+    (for/list ([sheet sheets])
+      (for/list ([rule sheet]
+                 [i (in-naturals)]
+                 #:when (for*/or ([elements elementss] [elt (in-tree elements)])
+                          (selector-matches? (car rule) elt)))
+        rule)))
+  (dict-set problem ':sheets sheets*))
 
 (define (classes-ids-used selector)
   (reap [class! id!]
@@ -58,8 +63,12 @@
      (append-map selectors-in-test args)]
     [_ '()]))
 
-(define (prune-attrs elts-stx sheets tests)
-  (define elts (parse-tree elts-stx))
+(define (prune-attrs problem)
+  (define tests (dict-ref problem ':tests))
+  (define sheets (dict-ref problem ':sheets))
+  (define doc (first (dict-ref problem ':documents)))
+  (define elts (parse-tree (dom-elements doc)))
+
   (define asserts
     (append
      tests
@@ -77,25 +86,18 @@
     (define old-id (node-get elt ':id))
     (when (and old-id (not (set-member? used-ids old-id)))
       (node-remove! elt ':id)))
-  (unparse-tree elts))
+  (dict-set problem ':documents (list (struct-copy dom doc [elements (unparse-tree elts)]))))
 
-(define (prune-box-attrs box-stx)
-  (define boxes (parse-tree box-stx))
+(define (prune-box-attrs problem)
+  (define doc (first (dict-ref problem ':documents)))
+  (define boxes (parse-tree (dom-boxes doc)))
   (for ([box (in-tree boxes)])
     (node-remove! box ':split))
-  (unparse-tree boxes))
+  (dict-set problem ':documents (list (struct-copy dom doc [boxes (unparse-tree boxes)]))))
 
-(define (prune-renumber boxes-stx elts-stx)
-  (define boxes (parse-tree boxes-stx))
-  (define elts (parse-tree elts-stx))
-  (define mapping (make-hash))
-  (for ([box (in-tree boxes)] #:when (node-get box ':elt))
-    (node-set! box ':elt (hash-ref! mapping (node-get box ':elt) (hash-count mapping))))
-  (for ([elt (in-tree elts)] #:when (node-get elt ':num))
-    (node-set! elt ':num (hash-ref! mapping (node-get elt ':num) (hash-count mapping))))
-  (values (unparse-tree boxes) (unparse-tree elts)))
-
-(define (prune-fonts fonts sheets)
+(define (prune-fonts problem)
+  (define fonts (dict-ref problem ':fonts))
+  (define sheets (dict-ref problem ':fonts))
   (define-values (families weights styles)
     (reap [f! w! s!]
       (f! "serif")
@@ -109,11 +111,43 @@
             ['font-weight (w! val)]
             ['font-style (s! val)]
             [_ (void)])))))
-  (filter
-   identity
-   (for/list ([font fonts])
-     (match-define (list size family weight style metrics ...) font)
-     (if (and (set-member? families family) (set-member? weights weight) (set-member? styles style))
-         font
-         #f))))
+  (define fonts*
+    (for/reap [reap] ([font fonts])
+      (match-define (list size family weight style metrics ...) font)
+      (when (and (set-member? families family)
+                 (set-member? weights weight)
+                 (set-member? styles style))
+        font)))
+  (dict-ref problem ':fonts fonts*))
 
+(define (prune-renumber problem)
+  (define doc (first (dict-ref problem ':documents)))
+  (define elts (parse-tree (dom-elements doc)))
+  (define boxes (parse-tree (dom-boxes doc)))
+
+  (define mapping (make-hash))
+  (for ([box (in-tree boxes)] #:when (node-get box ':elt))
+    (node-set! box ':elt (hash-ref! mapping (node-get box ':elt) (hash-count mapping))))
+  (for ([elt (in-tree elts)] #:when (node-get elt ':num))
+    (node-set! elt ':num (hash-ref! mapping (node-get elt ':num) (hash-count mapping))))
+
+  (dict-set problem ':documents
+            (list (struct-copy dom doc [elements (unparse-tree elts)]
+                               [boxes (unparse-tree boxes)]))))
+
+(define pruning-functions
+  (list prune-elements
+        prune-sheets
+        prune-attrs
+        prune-fonts
+        prune-renumber
+        prune-box-attrs))
+
+(define (prune-for-caching problem)
+  (define doc (first (dict-ref problem ':documents)))
+  (dict-set* problem
+             ':name '("[removed for caching]")
+             ':title '("[removed for caching]")
+             ':url '("[removed for caching]")
+             ':documents (list (struct-copy dom doc [name 'removed-for-caching]))
+             ':features '()))


### PR DESCRIPTION
This really simplifies the otherwise-horrible code in `modularize.rkt` to just execute a pipeline of functions, one at a time, on the problem.