### PR TITLE
Alter the Cassius backend to support proofs by induction on lists of indeterminate size

### DIFF
--- a/bench/just_list.rkt
+++ b/bench/just_list.rkt
@@ -1,0 +1,57 @@
+(define-stylesheet just_list
+   ((tag html) (display block))
+   ((tag body) (display block))
+   ((tag ul) (display block))
+   ((tag li) (display list-item))
+   ((tag body)
+    :browser
+    (margin-top (px 8))
+    (margin-right (px 8))
+    (margin-bottom (px 8))
+    (margin-left (px 8)))
+   ((tag ul)
+    :browser
+    (margin-top (em 1))
+    (margin-bottom (em 1))
+    (padding-left (px 40))))
+(define-fonts just_list
+  [16 "serif" 400 normal 16 0 1.5 1.5 19])
+(define-browser just_list
+  :matched true
+  :w (between 800 1920)
+  :h (between 600 1280)
+  :fs (between 16 32)
+  :fsm 12
+  :scrollw 10
+  :component)
+(define-document just_list
+((html :num 4 :class ())
+  ((body :num 5 :class ())
+   ((ul :num 0 :class ())
+    ((li :num 1 :class ()))
+    ((li :num 2 :class ()))
+    ((li :num 3 :class ()))))))
+(define-layout just_list (just_list just_list)
+ ((BLOCK :elt 0 :name list)
+  ((BLOCK :elt 1 :component true :spec))
+  ((BLOCK :elt 2 :component true :spec))
+  ((BLOCK :elt 3 :component true :spec))))
+(define-problem just_list
+  :title ""
+  :url "file:///home/p92/button_test_1.html"
+  :sheets just_list
+  :fonts just_list
+  :tests (forall
+   ()
+   (=>
+    (=>
+     (or (= (prev list) null) (non-negative-margins (prev list)))
+     (non-negative-margins list))))
+  (forall
+   (b)
+   (=>
+    (=>
+     (onscreen ?)
+     (=> (or (is-component b) (is-interactive b)) (onscreen b)))))
+  :layouts just_list
+  :features display:list-item empty-text tag:button display:inline-block float:0)

--- a/bench/just_list.rkt
+++ b/bench/just_list.rkt
@@ -1,4 +1,11 @@
-(define-stylesheet just_list
+; FACT(A, B): (>= (- (bottom B) (top A)) 0)
+; THEOREM: (>= (- (bottom (last list)) (top (first list))) 0)
+; - base: FACT(inductive-base, inductive-base)) ; 3 children (first, base, last)
+; - thm: FACT(indcutive-header, inductive-footer) => THEOREM ; 4 children (first, header, footer, last)
+; - ind: FACT(indcutive-header, inductive-footer) => FACT(inductive-header, inductive-step) ; 5 children (first, header, footer, step, last)
+
+; base
+(define-stylesheet base 
    ((tag html) (display block))
    ((tag body) (display block))
    ((tag ul) (display block))
@@ -14,9 +21,9 @@
     (margin-top (em 1))
     (margin-bottom (em 1))
     (padding-left (px 40))))
-(define-fonts just_list
+(define-fonts base
   [16 "serif" 400 normal 16 0 1.5 1.5 19])
-(define-browser just_list
+(define-browser base
   :matched true
   :w (between 800 1920)
   :h (between 600 1280)
@@ -24,34 +31,149 @@
   :fsm 12
   :scrollw 10
   :component)
-(define-document just_list
-((html :num 4 :class ())
-  ((body :num 5 :class ())
-   ((ul :num 0 :class ())
-    ((li :num 1 :class ()))
-    ((li :num 2 :class ()))
-    ((li :num 3 :class ()))))))
-(define-layout just_list (just_list just_list)
+
+(define-document base
+ ((html :num 4 :class ())
+   ((body :num 5 :class ())
+    ((ul :num 0 :class ())
+     ((li :num 1 :class ()))
+     ((li :num 2 :class ()))
+     ((li :num 3 :class ()))))))
+
+(define-layout base (base base)
  ((BLOCK :elt 0 :name list)
-  ((BLOCK :elt 1 :component true :spec))
-  ((BLOCK :elt 2 :component true :spec))
-  ((BLOCK :elt 3 :component true :spec))))
-(define-problem just_list
+  ((BLOCK :elt 1 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?))))
+  ((BLOCK :elt 2 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)) :name inductive-base))
+  ;; mystery elements go here
+  ((BLOCK :elt 3 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?))))))
+
+
+(define-problem base
   :title ""
   :url "file:///home/p92/button_test_1.html"
-  :sheets just_list
-  :fonts just_list
-  :tests (forall
-   ()
-   (=>
-    (=>
-     (or (= (prev list) null) (non-negative-margins (prev list)))
-     (non-negative-margins list))))
-  (forall
-   (b)
-   (=>
-    (=>
-     (onscreen ?)
-     (=> (or (is-component b) (is-interactive b)) (onscreen b)))))
-  :layouts just_list
+  :sheets base
+  :fonts base
+  :tests
+  (forall () ; base
+     (=> (= (floats-tracked list) 0)
+     (and (>= (- (bottom inductive-base) (top inductive-base)) 0) (= (floats-tracked inductive-base) (floats-tracked inductive-base)))))
+  :layouts base
+  :features display:list-item empty-text tag:button display:inline-block float:0)
+
+; thm
+(define-stylesheet thm
+   ((tag html) (display block))
+   ((tag body) (display block))
+   ((tag ul) (display block))
+   ((tag li) (display list-item))
+   ((tag body)
+    :browser
+    (margin-top (px 8))
+    (margin-right (px 8))
+    (margin-bottom (px 8))
+    (margin-left (px 8)))
+   ((tag ul)
+    :browser
+    (margin-top (em 1))
+    (margin-bottom (em 1))
+    (padding-left (px 40))))
+(define-fonts thm
+  [16 "serif" 400 normal 16 0 1.5 1.5 19])
+(define-browser thm
+  :matched true
+  :w (between 800 1920)
+  :h (between 600 1280)
+  :fs (between 16 32)
+  :fsm 12
+  :scrollw 10
+  :component)
+
+(define-document thm
+ ((html :num 5 :class ())
+   ((body :num 6 :class ())
+    ((ul :num 0 :class ())
+     ((li :num 1 :class ()))
+     ((li :num 2 :class ()))
+     ((li :num 3 :class ()))
+     ((li :num 4 :class ()))))))
+
+(define-layout thm (thm thm)
+ ((BLOCK :elt 0 :name list)
+  ((BLOCK :elt 1 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?))))
+  ((BLOCK :elt 2 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)) :name inductive-header :inductive-header))
+  ;; mystery elements go her
+  ((BLOCK :elt 3 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)) :name inductive-footer :inductive-footer))
+  ((BLOCK :elt 4 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?))))))
+
+
+(define-problem thm
+  :title ""
+  :url "file:///home/p92/button_test_1.html"
+  :sheets thm
+  :fonts thm
+  :tests
+  (forall () ; thm
+    (=> (and (and (>= (- (bottom inductive-footer) (top inductive-header)) 0) (= (floats-tracked inductive-header) (floats-tracked inductive-footer))) (= (floats-tracked list) 0))
+        (>= (- (bottom (last list)) (top (first list))) 0)))
+  :layouts thm
+  :features display:list-item empty-text tag:button display:inline-block float:0)
+
+; ind
+(define-stylesheet ind
+   ((tag html) (display block))
+   ((tag body) (display block))
+   ((tag ul) (display block))
+   ((tag li) (display list-item))
+   ((tag body)
+    :browser
+    (margin-top (px 8))
+    (margin-right (px 8))
+    (margin-bottom (px 8))
+    (margin-left (px 8)))
+   ((tag ul)
+    :browser
+    (margin-top (em 1))
+    (margin-bottom (em 1))
+    (padding-left (px 40))))
+(define-fonts ind
+  [16 "serif" 400 normal 16 0 1.5 1.5 19])
+(define-browser ind
+  :matched true
+  :w (between 800 1920)
+  :h (between 600 1280)
+  :fs (between 16 32)
+  :fsm 12
+  :scrollw 10
+  :component)
+
+(define-document ind
+ ((html :num 6 :class ())
+   ((body :num 7 :class ())
+    ((ul :num 0 :class ())
+     ((li :num 1 :class ()))
+     ((li :num 2 :class ()))
+     ((li :num 3 :class ()))
+     ((li :num 4 :class ()))
+     ((li :num 5 :class ()))))))
+
+(define-layout ind (ind ind)
+ ((BLOCK :elt 0 :name list)
+  ((BLOCK :elt 1 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?))))
+  ((BLOCK :elt 2 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)) :name inductive-header :inductive-header))
+  ;; mystery elements go here
+  ((BLOCK :elt 3 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)) :name inductive-footer :inductive-footer))
+  ((BLOCK :elt 4 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)) :name inductive-step))
+  ((BLOCK :elt 5 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?))))))
+
+
+(define-problem ind
+  :title ""
+  :url "file:///home/p92/button_test_1.html"
+  :sheets ind
+  :fonts ind
+  :tests
+  (forall () ; ind
+    (=> (and (>= (- (bottom inductive-footer) (top inductive-header)) 0) (= (floats-tracked inductive-header) (floats-tracked inductive-footer)))
+        (and (>= (- (bottom inductive-step) (top inductive-header) 0)) (= (floats-tracked inductive-header) (floats-tracked inductive-step)))))
+  :layouts ind
   :features display:list-item empty-text tag:button display:inline-block float:0)

--- a/bench/just_list.rkt
+++ b/bench/just_list.rkt
@@ -47,7 +47,6 @@
   ;; mystery elements go here
   ((BLOCK :elt 3 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?))))))
 
-
 (define-problem base
   :title ""
   :url "file:///home/p92/button_test_1.html"
@@ -58,6 +57,63 @@
      (=> (= (floats-tracked list) 0)
      (and (>= (- (bottom inductive-base) (top inductive-base)) 0) (= (floats-tracked inductive-base) (floats-tracked inductive-base)))))
   :layouts base
+  :features display:list-item empty-text tag:button display:inline-block float:0)
+
+; base2
+(define-stylesheet base2 
+   ((tag html) (display block))
+   ((tag body) (display block))
+   ((tag ul) (display block))
+   ((tag li) (display list-item))
+   ((tag body)
+    :browser
+    (margin-top (px 8))
+    (margin-right (px 8))
+    (margin-bottom (px 8))
+    (margin-left (px 8)))
+   ((tag ul)
+    :browser
+    (margin-top (em 1))
+    (margin-bottom (em 1))
+    (padding-left (px 40))))
+(define-fonts base2
+  [16 "serif" 400 normal 16 0 1.5 1.5 19])
+(define-browser base2
+  :matched true
+  :w (between 800 1920)
+  :h (between 600 1280)
+  :fs (between 16 32)
+  :fsm 12
+  :scrollw 10
+  :component)
+
+(define-document base2
+ ((html :num 5 :class ())
+   ((body :num 6 :class ())
+    ((ul :num 0 :class ())
+     ((li :num 1 :class ()))
+     ((li :num 2 :class ()))
+     ((li :num 3 :class ()))
+     ((li :num 4 :class ()))))))
+
+(define-layout base2 (base2 base2)
+ ((BLOCK :elt 0 :name list)
+  ((BLOCK :elt 1 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?))))
+  ((BLOCK :elt 2 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)) :name inductive-baseA))
+  ((BLOCK :elt 2 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)) :name inductive-baseB :no-next))
+  ;; mystery elements go here
+  ((BLOCK :elt 3 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)) :no-prev))))
+
+(define-problem base2
+  :title ""
+  :url "file:///home/p92/button_test_1.html"
+  :sheets base2
+  :fonts base2
+  :tests
+  (forall () ; base2
+     (=> (= (floats-tracked list) 0)
+     (and (>= (- (bottom inductive-baseB) (top inductive-baseA)) 0) (= (floats-tracked inductive-baseA) (floats-tracked inductive-baseB)))))
+  :layouts base2
   :features display:list-item empty-text tag:button display:inline-block float:0)
 
 ; thm
@@ -100,10 +156,10 @@
 (define-layout thm (thm thm)
  ((BLOCK :elt 0 :name list)
   ((BLOCK :elt 1 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?))))
-  ((BLOCK :elt 2 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)) :name inductive-header :inductive-header))
+  ((BLOCK :elt 2 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)) :name inductive-header :no-next))
   ;; mystery elements go her
-  ((BLOCK :elt 3 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)) :name inductive-footer :inductive-footer))
-  ((BLOCK :elt 4 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?))))))
+  ((BLOCK :elt 3 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)) :name inductive-footer :no-prev-or-next))
+  ((BLOCK :elt 4 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)) :no-prev))))
 
 
 (define-problem thm
@@ -159,11 +215,11 @@
 (define-layout ind (ind ind)
  ((BLOCK :elt 0 :name list)
   ((BLOCK :elt 1 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?))))
-  ((BLOCK :elt 2 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)) :name inductive-header :inductive-header))
+  ((BLOCK :elt 2 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)) :name inductive-header :no-next))
   ;; mystery elements go here
-  ((BLOCK :elt 3 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)) :name inductive-footer :inductive-footer))
-  ((BLOCK :elt 4 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)) :name inductive-step))
-  ((BLOCK :elt 5 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?))))))
+  ((BLOCK :elt 3 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)) :name inductive-footer :no-prev))
+  ((BLOCK :elt 4 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)) :name inductive-step :no-next))
+  ((BLOCK :elt 5 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)) :no-prev))))
 
 
 (define-problem ind

--- a/src/assertions.rkt
+++ b/src/assertions.rkt
@@ -19,7 +19,7 @@
    `((descends . ,(λ (b . sels) `(!= (ancestor ,b (matches ? ,@sels)) null)))
      (is-interactive . ,(λ (b) `(matches ,b (tag a) (tag input) (tag button))))
      (viewable . ,(λ (b) `(and (> (right ,b) (left root)) (> (bottom ,b) (top root)))))
-     (onscreen . ,(λ (b) `(and (>= (left ,b) (left root)) (>= (top ,b) (top root)))))
+     (onscreen . ,(λ (b) `(and (>= (top ,b) 0) (>= (left ,b) 0) )))
      (!= . ,(λ (a b) `(not (= ,a ,b))))
      (width . ,(λ (b [dir 'border]) `(- (right ,b ,dir) (left ,b ,dir))))
      (height . ,(λ (b [dir 'border]) `(- (bottom ,b ,dir) (top ,b ,dir))))

--- a/src/main.rkt
+++ b/src/main.rkt
@@ -120,10 +120,12 @@
   ;; TODO: complicated and possibly wrong
   (define link-function
     (cond
-     [(node-get* box ':inductive-header)
-      'link-box-inductive-header]
-     [(node-get* box ':inductive-footer)
-      'link-box-inductive-footer]
+     [(node-get* box ':no-next-or-prev)
+      'link-box-no-next-or-prev]
+     [(node-get* box ':no-next)
+      'link-box-no-next]
+     [(node-get* box ':no-prev)
+      'link-box-no-prev]
      [(dom-context dom ':component)
       'link-box-component]
      [(node-get* box ':component)

--- a/src/main.rkt
+++ b/src/main.rkt
@@ -115,6 +115,23 @@
 
     (emit `(assert (! ,constraint :named ,(sformat "~a/~a" fun (node-id elt)))))))
 
+;Sets up the special constraints needed to do a proof by induction on a given list
+(define (inductive-list-constraints dom emit box)
+  ;Note the header and footer of the list
+  (define header (node-fchild box))
+  (define footer (node-lchild box))
+  ;Note the box after the header and before the footer
+  (define leftbox (node-next header))
+  (define rightbox (node-prev footer))
+  ;Explicitely say what the neighbors and parent of the header are
+  (emit `(assert (and (= (pbox (dump-box header)) (dump-box box)) (= (vbox (dump-box header)) 0) (= (nbox (dump-box header)) (dump-box leftbox)))))
+  ;Explicitly state what the neighbors and parent of the footer are
+  (emit `(assert (and (= (pbox (dump-box footer)) (dump-box box)) (= (vbox (dump-box footer)) (dump-box rightbox)) (= (nbox (dump-box footer)) 0))))
+  ;Explicity state leftbox's neighbors and parent, leaving its next up to z3
+  (emit `(assert (and (= (pbox (dump-box leftbox)) (dump-box box)) (= (vbox (dump-box leftbox)) (dump-box header)))))
+  ;Explicitely state rightbox's neighbors and parent, leaving its previous up to z3
+  (emit `(addert (and (= (pbox (dump-box rightbox)) (dump-box box)) (= (nbox (dump-box rightbox)) (dump-box footer))))))
+
 (define (box-tree-constraints dom emit box)
   (define link-function
     (if (dom-context dom ':component)

--- a/src/main.rkt
+++ b/src/main.rkt
@@ -115,45 +115,30 @@
 
     (emit `(assert (! ,constraint :named ,(sformat "~a/~a" fun (node-id elt)))))))
 
-;Sets up the special constraints needed to do a proof by induction on a given list
-(define (inductive-list-constraints dom emit box)
-  ;Note the header and footer of the list
-  (define header (node-fchild box))
-  (define footer (node-lchild box))
-  (when (node-fchild box)
-    ;Note the box after the header and before the footer
-    (define leftbox (node-next header))
-    (define rightbox (node-prev footer))
-    (when (node-get* header ':inductive-header)
-      ;Explicitely say what the neighbors and parent of the header are
-      (emit `(assert (and (= (pbox ,(dump-box header)) ,(dump-box box)) (= (vbox ,(dump-box header)) no-box) (= (nbox ,(dump-box header)) ,(dump-box leftbox)))))
-      ;Explicitly state what the neighbors and parent of the footer are
-      (emit `(assert (and (= (pbox ,(dump-box footer)) ,(dump-box box)) (= (vbox ,(dump-box footer)) ,(dump-box rightbox)) (= (nbox ,(dump-box footer)) no-box))))
-      ;Explicity state leftbox's neighbors and parent, leaving its next up to z3
-      (emit `(assert (and (= (pbox ,(dump-box leftbox)) ,(dump-box box)) (= (vbox ,(dump-box leftbox)) ,(dump-box header)))))
-      ;Explicitely state rightbox's neighbors and parent, leaving its previous up to z3
-      (emit `(assert (and (= (pbox ,(dump-box rightbox)) ,(dump-box box)) (= (nbox ,(dump-box rightbox)) ,(dump-box footer))))))))
 
 (define (box-tree-constraints dom emit box)
-  (define skip false)
-  (when (node-fchild box)
-    (when (node-get* (node-fchild box) ':inductive-header)
-      (set! skip true)))
+  ;; TODO: complicated and possibly wrong
   (define link-function
-    (if (dom-context dom ':component)
-        'link-box-component
-        (if (node-get* box ':component)
-            'link-box-magic
-            'link-box)))
-  (when (equal? skip #f)
-    (emit `(assert (= (is-component ,(dump-box box)) ,(if (is-component box) 'true 'false))))
-    (emit `(assert (,link-function
-                    ,(dump-box box)
-                    ,(dump-box (node-parent box))
-                    ,(dump-box (node-prev box))
-                    ,(dump-box (node-next box))
-                    ,(dump-box (node-fchild box))
-                    ,(dump-box (node-lchild box)))))))
+    (cond
+     [(node-get* box ':inductive-header)
+      'link-box-inductive-header]
+     [(node-get* box ':inductive-footer)
+      'link-box-inductive-footer]
+     [(dom-context dom ':component)
+      'link-box-component]
+     [(node-get* box ':component)
+      'link-box-magic]
+     [else
+      'link-box]))
+  ;Set the constraints for a component assuming this is not the case of a proof by induction
+  (emit `(assert (= (is-component ,(dump-box box)) ,(if (is-component box) 'true 'false))))
+  (emit `(assert (,link-function
+                  ,(dump-box box)
+                  ,(dump-box (node-parent box))
+                  ,(dump-box (node-prev box))
+                  ,(dump-box (node-next box))
+                  ,(dump-box (node-fchild box))
+                  ,(dump-box (node-lchild box))))))
 
 
 (define (layout-constraints dom emit elt)
@@ -254,7 +239,6 @@
     ,@(for-render sheet-constraints doms (apply append sheets))
     ,@(for-render per-element tree-constraints)
     ,@(per-box box-tree-constraints)
-    ,@(per-box inductive-list-constraints)
     ,@(per-box position-constraints)
     ,@(for-render box-element-constraints doms)
     ,@(box-first-last-constraints doms)

--- a/src/spec/tree.rkt
+++ b/src/spec/tree.rkt
@@ -65,5 +65,13 @@
          (= (fbox box) f) (= (lbox box) l)))
 
   (define-fun link-box-magic ((box Box) (p Box) (v Box) (n Box) (f Box) (l Box)) Bool
-    (and (=> (is-box p) (and (= (pbox box) p) (= (vbox box) v) (= (nbox box) n))))))
+    (and (=> (is-box p) (and (= (pbox box) p) (= (vbox box) v) (= (nbox box) n)))))
+  
+   (define-fun link-box-inductive-header  ((box Box) (p Box) (v Box) (n Box) (f Box) (l Box)) Bool
+    (and (= (pbox box) p) (= (vbox box) v)))
+  
+   (define-fun link-box-inductive-footer  ((box Box) (p Box) (v Box) (n Box) (f Box) (l Box)) Bool
+    (and (= (pbox box) p) (= (nbox box) n)))
+
+  )
 

--- a/src/spec/tree.rkt
+++ b/src/spec/tree.rkt
@@ -67,11 +67,14 @@
   (define-fun link-box-magic ((box Box) (p Box) (v Box) (n Box) (f Box) (l Box)) Bool
     (and (=> (is-box p) (and (= (pbox box) p) (= (vbox box) v) (= (nbox box) n)))))
   
-   (define-fun link-box-inductive-header  ((box Box) (p Box) (v Box) (n Box) (f Box) (l Box)) Bool
+   (define-fun link-box-no-next  ((box Box) (p Box) (v Box) (n Box) (f Box) (l Box)) Bool
     (and (= (pbox box) p) (= (vbox box) v)))
   
-   (define-fun link-box-inductive-footer  ((box Box) (p Box) (v Box) (n Box) (f Box) (l Box)) Bool
+   (define-fun link-box-no-prev  ((box Box) (p Box) (v Box) (n Box) (f Box) (l Box)) Bool
     (and (= (pbox box) p) (= (nbox box) n)))
+
+   (define-fun link-box-no-next-or-prev  ((box Box) (p Box) (v Box) (n Box) (f Box) (l Box)) Bool
+    (and (= (pbox box) p)))
 
   )
 


### PR DESCRIPTION
In order to help support proofs on dynamic webpages Cassius must be able to do proofs by induction about facts of lists of indeterminate length such that the length changing doesn't force the proof to be redone. This will also drastically decrease the runtime needed to prove facts about such lists in both dynamic and non dynamic settings. To accomplish this the pull request does as follows

- [x] Adds a new problem document that was handmade to circumvent the front-end or outer layer
- [x] Alters main.rkt to support the obfuscations on a list needed for a proof by induction
- [ ] Add code that performs each of the needed steps for a proof by induction on the given list when supplied with a set of lists that supports such a proof