### PR TITLE
Alter the wrapper of cassius to allow for the proof language necessary to do a proof by induction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,9 @@ bench/joel
 bench/pages/
 bench/fwt.rkt
 bench/bugs.rkt
+bench/induction.rkt
 geckodriver.log
+cache
 previous/
 
 # Racket and TypeScript junk

--- a/Makefile
+++ b/Makefile
@@ -105,4 +105,4 @@ bench/induction.rkt: capture/capture.py capture/all.js bench/induction/list.html
 		'bench/induction/list.html#50'
 
 reports/induction.html reports/induction.json: bench/induction.proof bench/induction.rkt
-	racket src/report.rkt proofs $(FLAGS) --show-all --cache reports/induction.cache --timeout 600 -o reports/induction $^
+	racket src/report.rkt proofs $(FLAGS) --show-all --cache reports/induction.cache --timeout 600 -o reports/induction $<

--- a/Makefile
+++ b/Makefile
@@ -104,5 +104,5 @@ bench/induction.rkt: capture/capture.py capture/all.js bench/induction/list.html
 		'bench/induction/list.html#4' 'bench/induction/list.html#5' \
 		'bench/induction/list.html#50'
 
-reports/induction.html reports/induction.json: bench/induction.proof
+reports/induction.html reports/induction.json: bench/induction.proof bench/induction.rkt
 	racket src/report.rkt proofs $(FLAGS) --show-all --cache reports/induction.cache --timeout 600 -o reports/induction $^

--- a/Makefile
+++ b/Makefile
@@ -95,3 +95,11 @@ bench/bugs.rkt: capture/capture.py capture/all.js $(wildcard bench/bugs/*)
 
 reports/bugs.html: bench/bugs.rkt
 	racket src/report.rkt regression $(FLAGS) -o reports/bugs $^
+
+# Induction test suite
+bench/induction.rkt: capture/capture.py capture/all.js bench/induction/list.html bench/induction/prerun.js
+	@ $(CAPTURE) --output "$@" --prerun bench/induction/prerun.js \
+		'bench/induction/list.html#0' 'bench/induction/list.html#1' \
+		'bench/induction/list.html#2' 'bench/induction/list.html#3' \
+		'bench/induction/list.html#4' 'bench/induction/list.html#5' \
+		'bench/induction/list.html#50'

--- a/Makefile
+++ b/Makefile
@@ -103,3 +103,6 @@ bench/induction.rkt: capture/capture.py capture/all.js bench/induction/list.html
 		'bench/induction/list.html#2' 'bench/induction/list.html#3' \
 		'bench/induction/list.html#4' 'bench/induction/list.html#5' \
 		'bench/induction/list.html#50'
+
+reports/induction.html reports/induction.json: bench/induction.proof
+	racket src/report.rkt proofs $(FLAGS) --show-all --cache reports/induction.cache --timeout 600 -o reports/induction $^

--- a/bench/button_test_stress/button_test_stress.html
+++ b/bench/button_test_stress/button_test_stress.html
@@ -1,9 +1,0 @@
-  <html>
-  <body>
-  	<ul id="list">
-  	</ul>
-  	<script type="text/javascript" src="list_append.js">
-  	</script>
-  	<button type="button" id="add" onclick="add_element()">Click Me! </button>
-  </body>
-  </html>

--- a/bench/button_test_stress/list_append.js
+++ b/bench/button_test_stress/list_append.js
@@ -1,7 +1,0 @@
-function add_element(){
-  	var list = document.getElementById("list");
-  	let list_element = document.createElement('li');
-  	list.appendChild(list_element);
-  	list_element.id = 'element-' + list.getElementsByTagName("li").length;
-	list_element.innerHTML = "value-" + list.getElementsByTagName("li").length;
-}

--- a/bench/button_test_stress/prerun.js
+++ b/bench/button_test_stress/prerun.js
@@ -1,5 +1,0 @@
-click_event = new CustomEvent('click');
-add = document.querySelector('#add');
-for(i=0; i<50; i++) {
-  add.dispatchEvent(click_event);
-}

--- a/bench/induction.proof
+++ b/bench/induction.proof
@@ -1,0 +1,81 @@
+;; -*- mode: scheme -*-
+;; A Proof to verify the functionality of a simple website that uses java script
+;; By Skyler Griffith
+
+(import "common.thm")
+
+(page press-0 (load "induction.rkt" doc-1)
+      :w (between 800 1920)
+      :h (between 600 1280)
+      :fs (between 16 32))
+ 
+(page press-1 (load "induction.rkt" doc-2)
+      :w (between 800 1920)
+      :h (between 600 1280)
+      :fs (between 16 32))
+ 
+(page press-2 (load "induction.rkt" doc-3)
+      :w (between 800 1920)
+      :h (between 600 1280)
+      :fs (between 16 32))
+ 
+(page press-3 (load "induction.rkt" doc-4)
+      :w (between 800 1920)
+      :h (between 600 1280)
+      :fs (between 16 32))
+ 
+(page press-4 (load "induction.rkt" doc-5)
+      :w (between 800 1920)
+      :h (between 600 1280)
+      :fs (between 16 32))
+ 
+(page press-5 (load "induction.rkt" doc-6)
+      :w (between 800 1920)
+      :h (between 600 1280)
+      :fs (between 16 32))
+ 
+(page press-50 (load "induction.rkt" doc-7)
+      :w (between 800 1920)
+      :h (between 600 1280)
+      :fs (between 16 32))
+ 
+(theorem (top-above-bottom b)
+  (>= (- (bottom b) (top b) 0)))
+
+(proof (top-above-bottom top-above-bottom press-0 press-1 press-2 press-3 press-4 press-5)
+  (component list (id list))
+  (component button (tag button))
+  (components todos (child (id list) *))
+
+  (erase todos :text)
+  (assert todos (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)))
+  (pre list (= (floats-tracked ?) 0))
+  (induct list ; the inductive fact
+  	(and (>= (- (bottom inductive-footer) (top inductive-header)) 0) (= (floats-tracked inductive-footer) (floats-tracked inductive-header))))
+  (assert list (forall () (>= (- (bottom (last list)) (top (first list)) 0)))))
+
+(proof (stress-test top-above-bottom press-50)
+  (component list (id list))
+  (component button (tag button))
+  (components todos (child (id list) *))
+
+  (erase todos :text)
+  (assert todos (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)))
+  (pre list (= (floats-tracked ?) 0))
+  (induct list ; the inductive fact
+  	(and (>= (- (bottom inductive-footer) (top inductive-header)) 0) (= (floats-tracked inductive-footer) (floats-tracked inductive-header))))
+  (assert list (forall () (>= (- (bottom (last list)) (top (first list)) 0)))))
+
+(proof (interactive-onscreen interactive-onscreen press-0 press-1 press-2 press-3)
+  (component list (id list))
+  (component button (tag button))
+  (components todos (child (id list) *))
+  (erase todos :text)
+  (assert list 
+    (=> (or (= (prev list) null)
+            (non-negative-margins (prev list)))
+        (non-negative-margins list)))
+  (assert * (forall (b) (=> (onscreen ?)
+  		            (=> (or (is-component b) (is-interactive b)) (onscreen b)))))
+  (assert (- * list) (forall (t) (=> (has-type t text) (> (width t) 0) (non-negative-margins ?))))
+  (assert root (onscreen root)))

--- a/bench/induction/list.html
+++ b/bench/induction/list.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+<script>
+function add_element(e) {
+    let list = document.getElementById("list");
+    let n = list.children.length + 1;
+    let list_element = document.createElement('li');
+    list_element.id = 'element-' + n + '/' + window.iteration;
+    list_element.innerHTML = "value-" + n + '/' + window.iteration;
+    list.appendChild(list_element);
+}
+</script>
+<body>
+  <ul id="list"></ul>
+
+  <button type="button" id="click" onclick="add_element()">Click Me! </button>
+</body>
+</html>

--- a/bench/induction/prerun.js
+++ b/bench/induction/prerun.js
@@ -1,0 +1,7 @@
+let n = +location.hash.substr(1);
+let event = new CustomEvent('click');
+let elt = document.querySelector('#click');
+for (let i = 0; i < n; i++) {
+    window.iteration = i;
+    elt.dispatchEvent(event);
+}

--- a/bench/just_list.rkt
+++ b/bench/just_list.rkt
@@ -234,8 +234,14 @@
   :sheets ind
   :fonts ind
   :tests
-  (forall () ; ind
-    (=> (and (>= (- (bottom inductive-footer) (top inductive-header)) 0) (= (floats-tracked inductive-header) (floats-tracked inductive-footer)))
-        (and (>= (- (bottom inductive-step) (top inductive-header) 0)) (= (floats-tracked inductive-header) (floats-tracked inductive-step)))))
+   (forall
+    ()
+    (=>
+     (= (floats-tracked ?) 0)
+     (and (>= (- (bottom inductive-footer) (top inductive-header)) 0)
+          (=
+           (floats-tracked inductive-footer)
+           (floats-tracked inductive-header)))
+        (let ([inductive-footer inductive-step]) (and (>= (- (bottom inductive-footer) (top inductive-header)) 0) (= (floats-tracked inductive-footer) (floats-tracked inductive-header))))))
   :layouts ind
   :features display:list-item empty-text tag:button display:inline-block float:0)

--- a/bench/just_list.rkt
+++ b/bench/just_list.rkt
@@ -154,12 +154,12 @@
      ((li :num 4 :class ()))))))
 
 (define-layout thm (thm thm)
- ((BLOCK :elt 0 :name list)
-  ((BLOCK :elt 1 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?))))
-  ((BLOCK :elt 2 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)) :name inductive-header :no-next))
+ ((BLOCK :elt 0 :name list :component true) 
+  ((BLOCK :elt 1 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)) :component true))
+  ((BLOCK :elt 2 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)) :component true :name inductive-header :no-next #t))
   ;; mystery elements go her
-  ((BLOCK :elt 3 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)) :name inductive-footer :no-prev-or-next))
-  ((BLOCK :elt 4 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)) :no-prev))))
+  ((BLOCK :elt 3 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)) :component true :name inductive-footer :no-prev #t))
+  ((BLOCK :elt 4 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)) :component true))))
 
 
 (define-problem thm
@@ -168,9 +168,15 @@
   :sheets thm
   :fonts thm
   :tests
-  (forall () ; thm
-    (=> (and (and (>= (- (bottom inductive-footer) (top inductive-header)) 0) (= (floats-tracked inductive-header) (floats-tracked inductive-footer))) (= (floats-tracked list) 0))
-        (>= (- (bottom (last list)) (top (first list))) 0)))
+   (forall
+    ()
+    (=>
+     (= (floats-tracked ?) 0)
+     (and (>= (- (bottom inductive-footer) (top inductive-header)) 0)
+          (=
+           (floats-tracked inductive-footer)
+           (floats-tracked inductive-header)))
+     (>= (- (bottom (last list)) (top (first list)) 0))))
   :layouts thm
   :features display:list-item empty-text tag:button display:inline-block float:0)
 

--- a/bench/just_list.rkt
+++ b/bench/just_list.rkt
@@ -54,8 +54,8 @@
   :fonts base
   :tests
   (forall () ; base
-     (=> (= (floats-tracked list) 0)
-     (and (>= (- (bottom inductive-base) (top inductive-base)) 0) (= (floats-tracked inductive-base) (floats-tracked inductive-base)))))
+     (=> (= (floats-tracked ?) 0)
+     (let ([inductive-footer inductive-base] [inductive-header inductive-base]) (and (>= (- (bottom inductive-footer) (top inductive-header)) 0) (= (floats-tracked inductive-footer) (floats-tracked inductive-header))))))
   :layouts base
   :features display:list-item empty-text tag:button display:inline-block float:0)
 
@@ -100,9 +100,9 @@
  ((BLOCK :elt 0 :name list)
   ((BLOCK :elt 1 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?))))
   ((BLOCK :elt 2 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)) :name inductive-baseA))
-  ((BLOCK :elt 2 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)) :name inductive-baseB :no-next))
+  ((BLOCK :elt 3 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)) :name inductive-baseB :no-next))
   ;; mystery elements go here
-  ((BLOCK :elt 3 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)) :no-prev))))
+  ((BLOCK :elt 4 :component true :spec (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)) :no-prev))))
 
 (define-problem base2
   :title ""
@@ -111,8 +111,8 @@
   :fonts base2
   :tests
   (forall () ; base2
-     (=> (= (floats-tracked list) 0)
-     (and (>= (- (bottom inductive-baseB) (top inductive-baseA)) 0) (= (floats-tracked inductive-baseA) (floats-tracked inductive-baseB)))))
+     (=> (= (floats-tracked ?) 0)
+     (let ([inductive-footer inductive-baseB] [inductive-header inductive-baseA]) (and (>= (- (bottom inductive-footer) (top inductive-header)) 0) (= (floats-tracked inductive-footer) (floats-tracked inductive-header))))))
   :layouts base2
   :features display:list-item empty-text tag:button display:inline-block float:0)
 

--- a/bench/list_all.proof
+++ b/bench/list_all.proof
@@ -31,7 +31,9 @@
 	(component button (tag button))
 	(components todos (child (id list) *))
         (erase todos :text)
-
+        (induct list
+		;;inductive fact
+	)
         (assert list 
           (=> (or (= (prev list) null)
                   (non-negative-margins (prev list)))

--- a/bench/list_all.proof
+++ b/bench/list_all.proof
@@ -39,7 +39,6 @@
 	(component list (id list))
 	(component button (tag button))
 	(components todos (child (id list) *))
-	(erase todos :text)
         (induct list 
 		;;inductive fact
 		(and (>= (- (bottom inductive-base) (top inductive-base)) 0) (= (floats-tracked inductive-base) (floats-tracked inductive-base)))
@@ -50,18 +49,18 @@
 			(non-negative-margins b) (>= (height b) 0) (float-flow-skip b) 
 			(>= (- (bottom b) (top b) 0))))))
 
-(proof (interactive-onscreen interactive-onscreen zero-presses one-press two-presses three-presses)
-        (component list (id list))
-	(component button (tag button))
-	(components todos (child (id list) *))
-        (erase todos :text)
-        (assert list 
-          (=> (or (= (prev list) null)
-                  (non-negative-margins (prev list)))
-              (non-negative-margins list)))
-	(assert *
-	(forall(b) (=> (onscreen ?)
-			 (=> (or (is-component b) (is-interactive b)) (onscreen b)))))
-	(assert (- * list) (forall (t) (=> (has-type t text) (> (width t) 0) (non-negative-margins ?))))
-	(assert root (onscreen root))
-)
+;(proof (interactive-onscreen interactive-onscreen zero-presses one-press two-presses three-presses)
+;        (component list (id list))
+;	(component button (tag button))
+;	(components todos (child (id list) *))
+;        (erase todos :text)
+;        (assert list 
+;          (=> (or (= (prev list) null)
+;                  (non-negative-margins (prev list)))
+;              (non-negative-margins list)))
+;	(assert *
+;	(forall(b) (=> (onscreen ?)
+;			 (=> (or (is-component b) (is-interactive b)) (onscreen b)))))
+;	(assert (- * list) (forall (t) (=> (has-type t text) (> (width t) 0) (non-negative-margins ?))))
+;	(assert root (onscreen root))
+;)

--- a/bench/list_all.proof
+++ b/bench/list_all.proof
@@ -39,15 +39,15 @@
 	(component list (id list))
 	(component button (tag button))
 	(components todos (child (id list) *))
+	(assert todos (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)))
+	(pre list (= (floats-tracked ?) 0))
         (induct list 
 		;;inductive fact
-		(and (>= (- (bottom inductive-base) (top inductive-base)) 0) (= (floats-tracked inductive-base) (floats-tracked inductive-base)))
+		(and (>= (- (bottom inductive-footer) (top inductive-header)) 0) (= (floats-tracked inductive-footer) (floats-tracked inductive-header)))
 	)
-	(assert *
-	(forall (b) 
-		(=> 
-			(non-negative-margins b) (>= (height b) 0) (float-flow-skip b) 
-			(>= (- (bottom b) (top b) 0))))))
+	(assert list
+	(forall ()  
+			(>= (- (bottom (last list)) (top (first list)) 0)))))
 
 ;(proof (interactive-onscreen interactive-onscreen zero-presses one-press two-presses three-presses)
 ;        (component list (id list))

--- a/bench/list_all.proof
+++ b/bench/list_all.proof
@@ -26,14 +26,35 @@
         :fs (between 16 32)
 ) 
 
+(page four-presses (load "list_all.rkt" button_test_5)
+	:w (between 800 1920)
+	:h (between 600 1280)
+	:fs (between 16 32)
+)
+
+(theorem (top-above-bottom b)
+	(>= (- (bottom b) (top b) 0)))
+
+(proof (top-above-bottom top-above-bottom zero-presses one-press two-presses three-presses four-presses)
+	(component list (id list))
+	(component button (tag button))
+	(components todos (child (id list) *))
+	(erase todos :text)
+        (induct list 
+		;;inductive fact
+		(and (>= (- (bottom inductive-base) (top inductive-base)) 0) (= (floats-tracked inductive-base) (floats-tracked inductive-base)))
+	)
+	(assert *
+	(forall (b) 
+		(=> 
+			(non-negative-margins b) (>= (height b) 0) (float-flow-skip b) 
+			(>= (- (bottom b) (top b) 0))))))
+
 (proof (interactive-onscreen interactive-onscreen zero-presses one-press two-presses three-presses)
         (component list (id list))
 	(component button (tag button))
 	(components todos (child (id list) *))
         (erase todos :text)
-        (induct list
-		;;inductive fact
-	)
         (assert list 
           (=> (or (= (prev list) null)
                   (non-negative-margins (prev list)))

--- a/bench/list_all.rkt
+++ b/bench/list_all.rkt
@@ -167,3 +167,61 @@
   :fonts button_test_1
   :layouts button_test_1
   :features empty-text tag:button display:inline-block float:0)
+;; From file:///home/sgriffith/Cassius/bench/js/button_test_1/button_test_1.html
+
+(define-stylesheet button_test_5)
+
+(define-fonts button_test_5
+  [16 "serif" 400 normal 16 0 1.5 1.5 19]
+  [14 "sans-serif" 400 normal 14 0 1.5 1.5 17])
+
+(define-browser button_test_5
+  :matched true
+  :w 1280
+  :h 950
+  :fs 16
+  :fsm 12
+  :scrollw 10)
+
+(define-document button_test_5
+  ([html :num 0]
+   ([head :num 1])
+   ([body :num 2]
+    ([ul :num 3 :id list]
+     ([li :num 4 :id element-1] "value-1")
+     ([li :num 5 :id element-2] "value-2")
+     ([li :num 6 :id element-3] "value-3")
+     ([li :num 7 :id element-4] "value-4"))
+    ([script :num 8]) " "
+    ([button :num 9] "Click Me! "))))
+
+(define-layout button_test_5 (button_test_5 button_test_5)
+ ([VIEW :w 1280]
+  ([BLOCK :x 0 :y 0 :w 1280 :h 137 :elt 0]
+   ([BLOCK :x 8 :y 8 :w 1264 :h 121 :elt 2]
+    ([BLOCK :x 8 :y 8 :w 1264 :h 76 :elt 3]
+     ([BLOCK :x 48 :y 8 :w 1224 :h 19 :elt 4]
+      ([LINE]
+       ([TEXT :x 48 :y 8 :w 58 :h 19 :text "value-1"])))
+     ([BLOCK :x 48 :y 27 :w 1224 :h 19 :elt 5]
+      ([LINE]
+       ([TEXT :x 48 :y 27 :w 58 :h 19 :text "value-2"])))
+     ([BLOCK :x 48 :y 46 :w 1224 :h 19 :elt 6]
+      ([LINE]
+       ([TEXT :x 48 :y 46 :w 58 :h 19 :text "value-3"])))
+     ([BLOCK :x 48 :y 65 :w 1224 :h 19 :elt 7]
+      ([LINE]
+       ([TEXT :x 48 :y 65 :w 58 :h 19 :text "value-4"]))))
+    ([ANON]
+     ([LINE]
+      ([INLINE :x 8 :y 100 :w 95 :h 29 :elt 9]
+       ([LINE]
+        ([TEXT :x 23 :y 106 :w 65 :h 17 :text "Click Me! "])))))))))
+
+(define-problem button_test_5
+  :title ""
+  :url "file:///home/sgriffith/Cassius/bench/js/button_test_1/button_test_1.html"
+  :sheets firefox button_test_5
+  :fonts button_test_5
+  :layouts button_test_5
+  :features display:list-item empty-text tag:button display:inline-block float:0)

--- a/bench/list_all.rkt
+++ b/bench/list_all.rkt
@@ -1,0 +1,169 @@
+;; From file:///home/p92/button_test_1.html
+
+(define-stylesheet button_test_2)
+(define-fonts button_test_2
+  [16 "serif" 400 normal 16 0 1.5 1.5 19]
+  [14 "sans-serif" 400 normal 14 0 1 1 17])
+(define-browser button_test_2
+  :matched true
+  :w 1280
+  :h 950
+  :fs 16
+  :fsm 12
+  :scrollw 10)
+(define-document button_test_2
+  ([html :num 0]
+   ([head :num 1])
+   ([body :num 2]
+    ([ul :num 3 :id list]
+     ([li :num 4 :id element-1] "value-1"))
+    ([script :num 5]) " "
+    ([button :num 6] "Click Me! "))))
+(define-layout button_test_2 (button_test_2 button_test_2)
+ ([VIEW :w 1280]
+  ([BLOCK :x 0 :y 0 :w 1280 :h 80 :elt 0]
+   ([BLOCK :x 8 :y 8 :w 1264 :h 64 :elt 2]
+    ([BLOCK :x 8 :y 8 :w 1264 :h 19 :elt 3]
+     ([BLOCK :x 48 :y 8 :w 1224 :h 19 :elt 4]
+      ([LINE]
+       ([TEXT :x 48 :y 8 :w 60 :h 19 :text "value-1"]))))
+    ([ANON]
+     ([LINE]
+      ([INLINE :x 8 :y 43 :w 92 :h 29 :elt 6]
+       ([LINE]
+        ([TEXT :x 23 :y 49.5 :w 62 :h 16 :text "Click Me! "])))))))))
+(define-problem button_test_2
+  :title ""
+  :url "file:///home/p92/button_test_1.html"
+  :sheets firefox button_test_2
+  :fonts button_test_2
+  :layouts button_test_2
+  :features display:list-item empty-text tag:button display:inline-block float:0)
+;; From file:///home/p92/button_test_1.html
+(define-stylesheet button_test_3)
+(define-fonts button_test_3
+  [16 "serif" 400 normal 16 0 1.5 1.5 19]
+  [14 "sans-serif" 400 normal 14 0 1 1 17])
+(define-browser button_test_3
+  :matched true
+  :w 1280
+  :h 950
+  :fs 16
+  :fsm 12
+  :scrollw 10)
+(define-document button_test_3
+  ([html :num 0]
+   ([head :num 1])
+   ([body :num 2]
+    ([ul :num 3 :id list]
+     ([li :num 4 :id element-1] "value-1")
+     ([li :num 5 :id element-2] "value-2"))
+    ([script :num 6]) " "
+    ([button :num 7] "Click Me! "))))
+(define-layout button_test_3 (button_test_3 button_test_3)
+ ([VIEW :w 1280]
+  ([BLOCK :x 0 :y 0 :w 1280 :h 99 :elt 0]
+   ([BLOCK :x 8 :y 8 :w 1264 :h 83 :elt 2]
+    ([BLOCK :x 8 :y 8 :w 1264 :h 38 :elt 3]
+     ([BLOCK :x 48 :y 8 :w 1224 :h 19 :elt 4]
+      ([LINE]
+       ([TEXT :x 48 :y 8 :w 60 :h 19 :text "value-1"])))
+     ([BLOCK :x 48 :y 27 :w 1224 :h 19 :elt 5]
+      ([LINE]
+       ([TEXT :x 48 :y 27 :w 60 :h 19 :text "value-2"]))))
+    ([ANON]
+     ([LINE]
+      ([INLINE :x 8 :y 62 :w 92 :h 29 :elt 7]
+       ([LINE]
+        ([TEXT :x 23 :y 68.5 :w 62 :h 16 :text "Click Me! "])))))))))
+(define-problem button_test_3
+  :title ""
+  :url "file:///home/p92/button_test_1.html"
+  :sheets firefox button_test_3
+  :fonts button_test_3
+  :layouts button_test_3
+  :features display:list-item empty-text tag:button display:inline-block float:0)
+;; From file:///home/p92/button_test_1.html
+(define-stylesheet button_test_4)
+(define-fonts button_test_4
+  [16 "serif" 400 normal 16 0 1.5 1.5 19]
+  [14 "sans-serif" 400 normal 14 0 1 1 17])
+(define-browser button_test_4
+  :matched true
+  :w 1280
+  :h 950
+  :fs 16
+  :fsm 12
+  :scrollw 10)
+(define-document button_test_4
+  ([html :num 0]
+   ([head :num 1])
+   ([body :num 2]
+    ([ul :num 3 :id list]
+     ([li :num 4 :id element-1] "value-1")
+     ([li :num 5 :id element-2] "value-2")
+     ([li :num 6 :id element-3] "value-3"))
+    ([script :num 7]) " "
+    ([button :num 8] "Click Me! "))))
+(define-layout button_test_4 (button_test_4 button_test_4)
+ ([VIEW :w 1280]
+  ([BLOCK :x 0 :y 0 :w 1280 :h 118 :elt 0]
+   ([BLOCK :x 8 :y 8 :w 1264 :h 102 :elt 2]
+    ([BLOCK :x 8 :y 8 :w 1264 :h 57 :elt 3]
+     ([BLOCK :x 48 :y 8 :w 1224 :h 19 :elt 4]
+      ([LINE]
+       ([TEXT :x 48 :y 8 :w 60 :h 19 :text "value-1"])))
+     ([BLOCK :x 48 :y 27 :w 1224 :h 19 :elt 5]
+      ([LINE]
+       ([TEXT :x 48 :y 27 :w 60 :h 19 :text "value-2"])))
+     ([BLOCK :x 48 :y 46 :w 1224 :h 19 :elt 6]
+      ([LINE]
+       ([TEXT :x 48 :y 46 :w 60 :h 19 :text "value-3"]))))
+    ([ANON]
+     ([LINE]
+      ([INLINE :x 8 :y 81 :w 92 :h 29 :elt 8]
+       ([LINE]
+        ([TEXT :x 23 :y 87.5 :w 62 :h 16 :text "Click Me! "])))))))))
+(define-problem button_test_4
+  :title ""
+  :url "file:///home/p92/button_test_1.html"
+  :sheets firefox button_test_4
+  :fonts button_test_4
+  :layouts button_test_4
+  :features display:list-item empty-text tag:button display:inline-block float:0)
+;; From file:///home/p92/button_test_1.html
+(define-stylesheet button_test_1)
+(define-fonts button_test_1
+  [16 "serif" 400 normal 16 0 1.5 1.5 19]
+  [14 "sans-serif" 400 normal 14 0 1 1 17])
+(define-browser button_test_1
+  :matched true
+  :w 1280
+  :h 950
+  :fs 16
+  :fsm 12
+  :scrollw 10)
+(define-document button_test_1
+  ([html :num 0]
+   ([head :num 1])
+   ([body :num 2]
+    ([ul :num 3 :id list])
+    ([script :num 4]) " "
+    ([button :num 5] "Click Me! "))))
+(define-layout button_test_1 (button_test_1 button_test_1)
+ ([VIEW :w 1280]
+  ([BLOCK :x 0 :y 0 :w 1280 :h 45 :elt 0]
+   ([BLOCK :x 8 :y 8 :w 1264 :h 29 :elt 2]
+    ([BLOCK :x 8 :y 8 :w 1264 :h 0 :elt 3])
+    ([ANON]
+     ([LINE]
+      ([INLINE :x 8 :y 8 :w 92 :h 29 :elt 5]
+       ([LINE]
+        ([TEXT :x 23 :y 14.5 :w 62 :h 16 :text "Click Me! "])))))))))
+(define-problem button_test_1
+  :title ""
+  :url "file:///home/p92/button_test_1.html"
+  :sheets firefox button_test_1
+  :fonts button_test_1
+  :layouts button_test_1
+  :features empty-text tag:button display:inline-block float:0)

--- a/bench/list_all_box.rkt
+++ b/bench/list_all_box.rkt
@@ -1,0 +1,204 @@
+;; From file:///home/sgriffith/box_press/box_press.html
+
+(define-stylesheet no_press)
+
+(define-fonts no_press
+  [16 "serif" 400 normal 16 0 1.5 1.5 19]
+  [14 "sans-serif" 400 normal 14 0 1.5 1.5 17])
+
+(define-browser no_press
+  :matched true
+  :w 1280
+  :h 950
+  :fs 16
+  :fsm 12
+  :scrollw 10)
+
+(define-document no_press
+  ([html :num 0]
+   ([head :num 1])
+   ([body :num 2]
+    ([ul :num 3 :id list])
+    ([script :num 4]) " "
+    ([input :num 5 :id myText :w 218 :h 29 :type text]) " "
+    ([button :num 6] "Add "))))
+
+(define-layout no_press (no_press no_press)
+ ([VIEW :w 1280]
+  ([BLOCK :x 0 :y 0 :w 1280 :h 45 :elt 0]
+   ([BLOCK :x 8 :y 8 :w 1264 :h 29 :elt 2]
+    ([BLOCK :x 8 :y 8 :w 1264 :h 0 :elt 3])
+    ([ANON]
+     ([LINE]
+      ([INLINE :x 8 :y 8 :w 218 :h 29 :elt 5])
+      ([TEXT :x 226 :y 12 :w 5 :h 19 :text " "])
+      ([INLINE :x 231 :y 8 :w 58 :h 29 :elt 6]
+       ([LINE]
+        ([TEXT :x 246 :y 14 :w 28 :h 17 :text "Add "])))))))))
+
+(define-problem no_press
+  :title ""
+  :url "file:///home/sgriffith/box_test/box_test.html"
+  :sheets firefox no_press
+  :fonts no_press
+  :layouts no_press
+  :features empty-text tag:input tag:button display:inline-block float:0)
+
+
+;; From file:///home/sgriffith/box_press/box_press.html
+
+(define-stylesheet one_press)
+
+(define-fonts one_press
+  [16 "serif" 400 normal 16 0 1.5 1.5 19]
+  [14 "sans-serif" 400 normal 14 0 1.5 1.5 17])
+
+(define-browser one_press
+  :matched true
+  :w 1280
+  :h 950
+  :fs 16
+  :fsm 12
+  :scrollw 10)
+
+(define-document one_press
+  ([html :num 0]
+   ([head :num 1])
+   ([body :num 2]
+    ([ul :num 3 :id list]
+     ([li :num 4 :id element-1] "Buy Groceries"))
+    ([script :num 5]) " "
+    ([input :num 6 :id myText :w 218 :h 29 :type text]) " "
+    ([button :num 7] "Add "))))
+
+(define-layout one_press (one_press one_press)
+ ([VIEW :w 1280]
+  ([BLOCK :x 0 :y 0 :w 1280 :h 80 :elt 0]
+   ([BLOCK :x 8 :y 8 :w 1264 :h 64 :elt 2]
+    ([BLOCK :x 8 :y 8 :w 1264 :h 19 :elt 3]
+     ([BLOCK :x 48 :y 8 :w 1224 :h 19 :elt 4]
+      ([LINE]
+       ([TEXT :x 48 :y 8 :w 115 :h 19 :text "Buy Groceries"]))))
+    ([ANON]
+     ([LINE]
+      ([INLINE :x 8 :y 43 :w 218 :h 29 :elt 6])
+      ([TEXT :x 226 :y 47 :w 5 :h 19 :text " "])
+      ([INLINE :x 231 :y 43 :w 58 :h 29 :elt 7]
+       ([LINE]
+        ([TEXT :x 246 :y 49 :w 28 :h 17 :text "Add "])))))))))
+
+(one_press
+  :title ""
+  :url "file:///home/sgriffith/box_press/box_test.html"
+  :sheets firefox one_press
+  :fonts one_press
+  :layouts one_press
+  :features display:list-item empty-text tag:input tag:button display:inline-block float:0)
+
+;; From file:///home/sgriffith/box_press/box_press.html
+
+(define-stylesheet two_press)
+
+(define-fonts two_press
+  [16 "serif" 400 normal 16 0 1.5 1.5 19]
+  [14 "sans-serif" 400 normal 14 0 1.5 1.5 17])
+(define-browser two_press
+  :matched true
+  :w 1280
+  :h 950
+  :fs 16
+  :fsm 12
+  :scrollw 10)
+(define-document two_press
+  ([html :num 0]
+   ([head :num 1])
+   ([body :num 2]
+    ([ul :num 3 :id list]
+     ([li :num 4 :id element-1] "Buy Groceries")
+     ([li :num 5 :id element-2] "Brush Dog"))
+    ([script :num 6]) " "
+    ([input :num 7 :id myText :w 218 :h 29 :type text]) " "
+    ([button :num 8] "Add "))))
+
+(define-layout two_press (two_press two_press)
+ ([VIEW :w 1280]
+  ([BLOCK :x 0 :y 0 :w 1280 :h 99 :elt 0]
+   ([BLOCK :x 8 :y 8 :w 1264 :h 83 :elt 2]
+    ([BLOCK :x 8 :y 8 :w 1264 :h 38 :elt 3]
+     ([BLOCK :x 48 :y 8 :w 1224 :h 19 :elt 4]
+      ([LINE]
+       ([TEXT :x 48 :y 8 :w 115 :h 19 :text "Buy Groceries"])))
+     ([BLOCK :x 48 :y 27 :w 1224 :h 19 :elt 5]
+      ([LINE]
+       ([TEXT :x 48 :y 27 :w 86 :h 19 :text "Brush Dog"]))))
+    ([ANON]
+     ([LINE]
+      ([INLINE :x 8 :y 62 :w 218 :h 29 :elt 7])
+      ([TEXT :x 226 :y 66 :w 5 :h 19 :text " "])
+      ([INLINE :x 231 :y 62 :w 58 :h 29 :elt 8]
+       ([LINE]
+        ([TEXT :x 246 :y 68 :w 28 :h 17 :text "Add "])))))))))
+(define-problem two_press
+  :title ""
+  :url "file:///home/sgriffith/box_test/box_test.html"
+  :sheets firefox two_press
+  :fonts two_press
+  :layouts two_press
+  :features display:list-item empty-text tag:input tag:button display:inline-block float:0)
+; From file:///home/sgriffith/box_test/box_test.html
+
+(define-stylesheet three_press)
+
+(define-fonts three_press
+  [16 "serif" 400 normal 16 0 1.5 1.5 19]
+  [14 "sans-serif" 400 normal 14 0 1.5 1.5 17])
+
+(define-browser three_press
+  :matched true
+  :w 1280
+  :h 950
+  :fs 16
+  :fsm 12
+  :scrollw 10)
+
+(define-document three_press
+  ([html :num 0]
+   ([head :num 1])
+   ([body :num 2]
+    ([ul :num 3 :id list]
+     ([li :num 4 :id element-1] "Buy Groceries")
+     ([li :num 5 :id element-2] "Brush Dog")
+     ([li :num 6 :id element-3] "Destroy Capatilism"))
+    ([script :num 7]) " "
+    ([input :num 8 :id myText :w 218 :h 29 :type text]) " "
+    ([button :num 9] "Add "))))
+
+(define-layout three_press (three_press three_press)
+ ([VIEW :w 1280]
+  ([BLOCK :x 0 :y 0 :w 1280 :h 118 :elt 0]
+   ([BLOCK :x 8 :y 8 :w 1264 :h 102 :elt 2]
+    ([BLOCK :x 8 :y 8 :w 1264 :h 57 :elt 3]
+     ([BLOCK :x 48 :y 8 :w 1224 :h 19 :elt 4]
+      ([LINE]
+       ([TEXT :x 48 :y 8 :w 115 :h 19 :text "Buy Groceries"])))
+     ([BLOCK :x 48 :y 27 :w 1224 :h 19 :elt 5]
+      ([LINE]
+       ([TEXT :x 48 :y 27 :w 86 :h 19 :text "Brush Dog"])))
+     ([BLOCK :x 48 :y 46 :w 1224 :h 19 :elt 6]
+      ([LINE]
+       ([TEXT :x 48 :y 46 :w 154 :h 19 :text "Destroy Capatilism"]))))
+    ([ANON]
+     ([LINE]
+      ([INLINE :x 8 :y 81 :w 218 :h 29 :elt 8])
+      ([TEXT :x 226 :y 85 :w 5 :h 19 :text " "])
+      ([INLINE :x 231 :y 81 :w 58 :h 29 :elt 9]
+       ([LINE]
+       ([TEXT :x 246 :y 87 :w 28 :h 17 :text "Add "])))))))))
+
+(define-problem three_press
+  :title ""
+  :url "file:///home/sgriffith/box_test/box_test.html"
+  :sheets firefox three_press
+  :fonts three_press
+  :layouts three_press
+  :features display:list-item empty-text tag:input tag:button display:inline-block float:0)

--- a/capture/browser.ts
+++ b/capture/browser.ts
@@ -12,7 +12,7 @@ function compute_scrollbar_width() {
     outer.appendChild(inner);
     document.body.appendChild(outer);
     var out = outer.offsetWidth - outer.clientWidth;
-    document.body.removeChild(outer)
+    outer.remove();
     return out;
 }
 
@@ -25,7 +25,9 @@ function default_font_size(family, features) {
     div.style.fontSize = "medium";
     div.style.fontWeight = "400";
     div.style.fontStyle = "normal";
-    return val2px(cs(div, "font-size"), features);
+    var out = val2px(cs(div, "font-size"), features);
+    div.remove();
+    return out;
 }
 
 function browser_info(features) {

--- a/capture/capture.py
+++ b/capture/capture.py
@@ -112,6 +112,8 @@ def main(urls, prerun=None, fd=None):
                 text = browser.capture(url, n, prerun=prerun)
             except selenium.common.exceptions.JavascriptException as e:
                 print("JS Exception in {}: {}".format(n, e.msg), file=sys.stderr)
+                if e.stacktrace:
+                    print("\n".join(e.stacktrace))
             else:
                 fd.write(text)
                 captured += 1

--- a/capture/fonts.ts
+++ b/capture/fonts.ts
@@ -42,7 +42,7 @@ function get_font_metrics(font) {
     div.removeChild(img);
     div.innerHTML = "H";
     var ascent = div.getBoundingClientRect().height - descent;
-    body.removeChild(div);
+    div.remove();
     return { a: ascent, d: descent};
 }
 
@@ -72,7 +72,7 @@ function get_font_lineheight(font) {
 
     var div_rect = div.getBoundingClientRect();
     var lineheight = div_rect.height;
-    body.removeChild(div);
+    div.remove();
     return lineheight;
 }
 
@@ -118,7 +118,7 @@ function get_font_offsets(font) {
 
     var span_rect = span.getBoundingClientRect();
     var div_rect = div.getBoundingClientRect();
-    body.removeChild(div);
+    div.remove();
 
     return { top: div_rect.top - span_rect.top, bottom: span_rect.bottom - div_rect.top };
 }

--- a/capture/util.ts
+++ b/capture/util.ts
@@ -63,9 +63,9 @@ export function val2px(val, features) {
         return +val.substr(0, val.length - 2)*96;
     } else if (match = val.match(/^([-+0-9.e]+)([a-z]+)$/)) {
         features["unit:" + match[2]] = true;
-        throw "Error, " + val + " is not a known unit";
+        throw Error("Error, " + val + " is not a known unit");
     } else {
-        throw "Error, " + val + " is not a pixel quantity."
+        throw Error("Error, " + val + " is not a pixel quantity.");
     }
 }
 
@@ -73,7 +73,7 @@ export function val2pct(val : string, _) {
     if (val.match(/^[-+0-9.e]+%$/)) {
         return +val.substr(0, val.length - 1);
     } else {
-        throw "Error, " + val + " is not a percentage quantity."
+        throw Error("Error, " + val + " is not a percentage quantity.");
     }
 }
 
@@ -86,7 +86,7 @@ export function val2em(val, features) {
         features["unit:ex"] = true;
         return +val.substr(0, val.length - 2) / 16 * 9;
     } else {
-        throw "Error, " + val + " is not a em quantity."
+        throw Error("Error, " + val + " is not a em quantity.");
     }
 }
 

--- a/infra/test.sh
+++ b/infra/test.sh
@@ -45,7 +45,7 @@ done | xargs make -j$THREADS bench/fwt.rkt
 make FWT_PATH="$FWT_PATH" FLAGS="--threads $THREADS --cache reports/run.cache" \
      reports/csswg.html reports/bugs.html \
      reports/fwt.html reports/vizassert.html reports/specific.html \
-     reports/modular.html
+     reports/modular.html reports/induction.html
 
 mkdir -p reports/rkt/
 mkdir -p reports/json/

--- a/src/modularize.rkt
+++ b/src/modularize.rkt
@@ -55,7 +55,7 @@
     ;;When induction is requested and the list given has at least 4 elements create and return the list of cases for induction
     [(and (and (and (and (and (node-lchild thm-box) (node-fchild thm-box)) (and (node-next (node-fchild thm-box)) (node-prev (node-lchild thm-box)))) (and (not (equal? (node-next (node-fchild thm-box)) (node-lchild thm-box))) (not (equal? (node-next (node-fchild thm-box)) (node-prev (node-lchild thm-box))))))) (node-get* thm-box ':inductive-fact))
      (begin
-       (eprintf "Found inductive fact ~a\n" (node-get* thm-box ':inductive-fact))
+       ;(eprintf "Found inductive fact ~a\n" (node-get* thm-box ':inductive-fact))
        ;;Create the document/proof for the base case
        ;;Create the document/proof for the base2 case
        ;;Create the document/proof for the thm case
@@ -65,26 +65,27 @@
        ;;Name the inductive header and footer
        (node-set! (node-next (node-fchild thm-box)) ':name 'inductive-header)
        (node-set! (node-prev (node-lchild thm-box)) ':name 'inductive-footer)
-       (pretty-print (node-next (node-fchild thm-box)))
-       (pretty-print (node-prev (node-lchild thm-box)))
        ;;Reconstruct the proof to fit the inductive fact into the set of pre conditions
        (match-define (list `(forall (,varss ...) (=> ,press ... ,posts)) ...) postcondition)
+       ;(pretty-print posts)
        (define thm-test 
 	 (for/list ([vars varss] [pres press] [post posts])
+	   ;(pretty-print post)
 	   `(forall (,@vars) (=> ,@pres ,@(node-get* thm-box ':inductive-fact) ,post))))
-       (pretty-print thm-test)
        ;;Create the document/proof for the ind case
        ;;Return a list of the documents of each of the cases
-       (list (cons (unparse-tree thm-box) thm-test)))]))
+       (list (cons (struct-copy dom component-document 
+				[boxes (unparse-tree thm-box)])
+		   thm-test)))]))
 
 (define (modularize problem)
   (define fonts (dict-ref problem ':fonts))
   (define sheets (dict-ref problem ':sheets))
   (for*/list ([doc (dict-ref problem ':documents)] 
 	      [(name thing) (split-document doc)]
-	      [cases (inductive-cases (car thing) 'todo-no-precondition (cdr thing))]
+	      [case* (inductive-cases (car thing) 'todo-no-precondition (cdr thing))]
               #:unless (null? (cdr thing)))
-    (match-define (cons piece specs) thing)
+    (match-define (cons piece specs) case*)
     (define problem*
       (dict-set* problem
                  ':documents (list piece)

--- a/src/modularize.rkt
+++ b/src/modularize.rkt
@@ -50,35 +50,36 @@
   (define thm-box (parse-tree (dom-boxes component-document)))
   (define ind-dom (parse-dom component-document))
   (define ind-box (dom-boxes ind-dom))
+  (define ind-fact (node-get* thm-box ':inductive-fact))
   ;;If the list has an inductive fact and it has 4 or more elements, set up a proof by induction
   (cond
     ;;When no induction is requested, do nothing
-    [(not (node-get* thm-box ':inductive-fact))
+    [(not ind-fact)
      (list (cons component-document postcondition))]
     ;;When induction is requested, but the list given doesn't have at leaste for elements, print out a warning and do nothing
-    [(and (not (and (and (and (and (node-lchild thm-box) (node-fchild thm-box)) (and (node-next (node-fchild thm-box)) (node-prev (node-lchild thm-box)))) (and (not (equal? (node-next (node-fchild thm-box)) (node-lchild thm-box))) (not (equal? (node-next (node-fchild thm-box)) (node-prev (node-lchild thm-box))))))))  (node-get* thm-box ':inductive-fact))
-     (begin
+    [(and (< (length (node-children thm-box)) 4) ind-fact)
+    (begin
        (eprintf "Warning: ~a is to small to induct over on page one of the given pages. ~a Must have at least 4 elements. Skipping induction for ~a\n"   (node-get* thm-box ':name) (node-get* thm-box ':name) (node-get* thm-box ':name))
        (list (cons component-document postcondition)))]
     ;;When induction is requested and the list given has at least 4 elements create and return the list of cases for induction
-    [(and (and (and (and (and (node-lchild thm-box) (node-fchild thm-box)) (and (node-next (node-fchild thm-box)) (node-prev (node-lchild thm-box)))) (and (not (equal? (node-next (node-fchild thm-box)) (node-lchild thm-box))) (not (equal? (node-next (node-fchild thm-box)) (node-prev (node-lchild thm-box))))))) (node-get* thm-box ':inductive-fact))
+     [(and (>= (length (node-children thm-box)) 4) ind-fact)
      (begin
-       (eprintf "Found inductive fact ~a\n" (node-get* thm-box ':inductive-fact))
+       (eprintf "Found inductive fact ~a\n" ind-fact)
        ;;Create the document/proof for the base case
        ;;Name the inductive base
-;       (node-set! (node-next (node-fchild base-box)) ':name 'inductive-base)
+       (node-set! (node-next (node-fchild base-box)) ':name 'inductive-base)
        ;;Remove the nodes that arent the first, last, or inductive base form the lisit
-;       (for ([child (node-children base-box)]
-;	    #:unless (or (equal? child (node-fchild base-box)) (equal? child (node-next (node-fchild base-box))) (equal? child (node-lchild base-box))))
-;		(delete-node! child))
-;       (for ([child-elt (node-children base-elt)]
-;	    #:unless (or (equal? child-elt (node-fchild base-elt)) (equal? child-elt (node-next (node-fchild base-elt))) (equal? child-elt (node-lchild base-elt))))
-;		(delete-node! child-elt))
+       (for ([child (node-children base-box)]
+	    #:unless (or (equal? child (node-fchild base-box)) (equal? child (node-next (node-fchild base-box))) (equal? child (node-lchild base-box))))
+		(delete-node! child))
+       (for ([child-elt (node-children base-elt)]
+	    #:unless (or (equal? child-elt (node-fchild base-elt)) (equal? child-elt (node-next (node-fchild base-elt))) (equal? child-elt (node-lchild base-elt))))
+		(delete-node! child-elt))
        ;;Reconstruct the proof to fit the inductive fact into the set of pre conditions
-;       (match-define (list `(forall (,base-varss ...) (=> ,base-press ... ,base-posts)) ...) postcondition)
- ;      (define base-test 
-;	 (for/list ([base-vars base-varss] [base-pres base-press] [base-post base-posts])
-;	   `(forall (,@base-vars) (=> ,@base-pres  (let ([inductive-footer inductive-base] [inductive-header inductive-base]) ,@(node-get* base-box ':inductive-fact))))))
+       (match-define (list `(forall (,base-varss ...) (=> ,base-press ... ,base-posts)) ...) postcondition)
+       (define base-test 
+	 (for/list ([base-vars base-varss] [base-pres base-press] [base-post base-posts])
+	   `(forall (,@base-vars) (=> ,@base-pres  (let ([inductive-footer inductive-base] [inductive-header inductive-base]) ,@ind-fact)))))
        ;;Create the document/proof for the base2 case
        ;;Add the relevant tags to the list boxes
        (node-set! (node-prev (node-lchild base2-box)) ':no-next #t)
@@ -87,59 +88,55 @@
        (node-set! (node-next (node-fchild base2-box)) ':name 'inductive-baseA)
        (node-set! (node-prev (node-lchild base2-box)) ':name 'inductive-baseB)
        ;;Remove the nodes that arent the first, last, or inductive base form the lisit
-       (pretty-print (node-children base2-box))
        (for ([child2 (node-children base2-box)]
 	    #:unless (or (equal? child2 (node-fchild base2-box)) (equal? child2 (node-next (node-fchild base2-box))) (equal? child2 (node-prev (node-lchild base2-box))) (equal? child2 (node-lchild base2-box))))
 		(delete-node! child2))
-       (pretty-print (node-children base2-box))
-       (pretty-print (node-children base2-elt))
        (for ([child2-elt (node-children base2-elt)]
 	    #:unless (or (equal? child2-elt (node-fchild base2-elt)) (equal? child2-elt (node-next (node-fchild base2-elt))) (equal? child2-elt (node-prev (node-lchild base2-elt))) (equal? child2-elt (node-lchild base2-elt))))
 		(delete-node! child2-elt))
-       (pretty-print (node-children base2-elt))
        ;;Reconstruct the proof to fit the inductive fact into the set of pre conditions
        (match-define (list `(forall (,base2-varss ...) (=> ,base2-press ... ,base2-posts)) ...) postcondition)
        (define base2-test 
 	 (for/list ([base2-vars base2-varss] [base2-pres base2-press] [base2-post base2-posts])
-	   `(forall (,@base2-vars) (=> ,@base2-pres  (let ([inductive-footer inductive-baseB] [inductive-header inductive-baseA]) ,@(node-get* base2-box ':inductive-fact))))))
+	   `(forall (,@base2-vars) (=> ,@base2-pres  (let ([inductive-footer inductive-baseB] [inductive-header inductive-baseA]) ,@ind-fact)))))
        ;;Create the document/proof for the thm case
        ;;Add the proper tags to the inductive header, inductive footer, and end of the list to get the correct inductive behaviour from Cassius
-;       (node-set! (node-next (node-fchild thm-box)) ':no-next #t)
-;       (node-set! (node-prev (node-lchild thm-box)) ':no-prev #t)
+       (node-set! (node-next (node-fchild thm-box)) ':no-next #t)
+       (node-set! (node-prev (node-lchild thm-box)) ':no-prev #t)
        ;;Name the inductive header and footer
-;       (node-set! (node-next (node-fchild thm-box)) ':name 'inductive-header)
-;       (node-set! (node-prev (node-lchild thm-box)) ':name 'inductive-footer)
+       (node-set! (node-next (node-fchild thm-box)) ':name 'inductive-header)
+       (node-set! (node-prev (node-lchild thm-box)) ':name 'inductive-footer)
        ;;Reconstruct the proof to fit the inductive fact into the set of pre conditions
-;       (match-define (list `(forall (,thm-varss ...) (=> ,thm-press ... ,thm-posts)) ...) postcondition)
-;       (define thm-test 
-;	 (for/list ([thm-vars thm-varss] [thm-pres thm-press] [thm-post thm-posts])
-;	   `(forall (,@thm-vars) (=> ,@thm-pres ,@(node-get* thm-box ':inductive-fact) ,thm-post))))
+       (match-define (list `(forall (,thm-varss ...) (=> ,thm-press ... ,thm-posts)) ...) postcondition)
+       (define thm-test 
+	 (for/list ([thm-vars thm-varss] [thm-pres thm-press] [thm-post thm-posts])
+	   `(forall (,@thm-vars) (=> ,@thm-pres ,@ind-fact ,thm-post))))
        ;;Create the document/proof for the ind case
        ;;Create and add the node for the inductive-step
-;       (define ind-clone (clone-node (node-prev (node-lchild ind-box))))
-;       (add-node-before! (node-prev (node-lchild ind-box)) ind-clone)
-;       (define ind-elt-clone (clone-node (node-prev (node-lchild (dom-box->elt ind-dom ind-box)))))
-;       (add-node-before! (node-prev (node-lchild (dom-box->elt ind-dom ind-box))) ind-elt-clone)
-;       (node-set! (node-prev (node-prev (node-lchild ind-box))) ':elt (node-id ind-elt-clone))
+       (define ind-clone (clone-node (node-prev (node-lchild ind-box))))
+       (add-node-before! (node-prev (node-lchild ind-box)) ind-clone)
+       (define ind-elt-clone (clone-node (node-prev (node-lchild (dom-box->elt ind-dom ind-box)))))
+       (add-node-before! (node-prev (node-lchild (dom-box->elt ind-dom ind-box))) ind-elt-clone)
+       (node-set! (node-prev (node-prev (node-lchild ind-box))) ':elt (node-id ind-elt-clone))
        ;;Add the proper tags to the inductive header, inductive footer, and end of the list to get the correct inductive behaviour from Cassius
-;       (node-set! (node-next (node-fchild ind-box)) ':no-next #t)
-;       (node-set! (node-prev (node-prev (node-lchild ind-box))) ':no-prev #t)
-;       (node-set! (node-prev (node-lchild ind-box)) ':no-next #t)
-;       (node-set! (node-lchild ind-box) ':no-prev #t)
+       (node-set! (node-next (node-fchild ind-box)) ':no-next #t)
+       (node-set! (node-prev (node-prev (node-lchild ind-box))) ':no-prev #t)
+       (node-set! (node-prev (node-lchild ind-box)) ':no-next #t)
+       (node-set! (node-lchild ind-box) ':no-prev #t)
        ;;Name the inductive header, step, and footer
-;       (node-set! (node-next (node-fchild ind-box)) ':name 'inductive-header)
-;       (node-set! (node-prev (node-prev (node-lchild ind-box))) ':name 'inductive-footer)
-;       (node-set! (node-prev (node-lchild ind-box)) ':name 'inductive-step)
+       (node-set! (node-next (node-fchild ind-box)) ':name 'inductive-header)
+       (node-set! (node-prev (node-prev (node-lchild ind-box))) ':name 'inductive-footer)
+       (node-set! (node-prev (node-lchild ind-box)) ':name 'inductive-step)
        ;;Reconstruct the proof to fit the inductive fact into the set of pre conditions
-;       (match-define (list `(forall (,ind-varss ...) (=> ,ind-press ... ,ind-posts)) ...) postcondition)
-;       (define ind-test 
-;	 (for/list ([ind-vars ind-varss] [ind-pres ind-press] [ind-post ind-posts])
-;	   `(forall (,@ind-vars) (=> ,@ind-pres ,@(node-get* ind-box ':inductive-fact) (let ([inductive-footer inductive-step]) ,@(node-get* ind-box ':inductive-fact))))))
+       (match-define (list `(forall (,ind-varss ...) (=> ,ind-press ... ,ind-posts)) ...) postcondition)
+       (define ind-test 
+	 (for/list ([ind-vars ind-varss] [ind-pres ind-press] [ind-post ind-posts])
+	   `(forall (,@ind-vars) (=> ,@ind-pres ,@ind-fact (let ([inductive-footer inductive-step]) ,@ind-fact)))))
        ;;Return a list of the documents of each of the cases
-       (list #|(cons (unparse-dom base-dom) base-test)|#
+       (list (cons (unparse-dom base-dom) base-test)
 	     (cons (unparse-dom base2-dom) base2-test)
-	     #|(cons (struct-copy dom component-document [boxes (unparse-tree thm-box)]) thm-test)|#
-	     #|(cons (unparse-dom ind-dom) ind-test)|#))]))
+	     (cons (struct-copy dom component-document [boxes (unparse-tree thm-box)]) thm-test)
+	     (cons (unparse-dom ind-dom) ind-test)))]))
 
 (define (modularize problem)
   (define fonts (dict-ref problem ':fonts))

--- a/src/modularize.rkt
+++ b/src/modularize.rkt
@@ -161,6 +161,7 @@
   (define list-box (dom-boxes list-dom))
   (define list-elt (dom-box->elt list-dom list-box))
   (define ind-fact (node-get* list-box ':inductive-fact))
+  (define name (node-get list'box ':name))
   ;;If the list has an inductive fact and it has 4 or more elements, set up a proof by induction
   (cond
     ;;When no induction is requested, do nothing
@@ -169,10 +170,10 @@
     ;;When induction is requested, but the list given is empty, print out a warning and do nothing
     [(and (= (length (node-children list-box)) 0) ind-fact)
     (begin
-       (eprintf "Warning: ~a is Empty, and can not be inducted over. Cassius induction requires that  ~a  have at least 1 element. Skipping induction for ~a\n"   (node-get* list-box ':name) (node-get* list-box ':name) (node-get* list-box ':name))
+       (eprintf "Warning: Cannot induct over empty component ~a. Proving ~a directly\n" name name name)
        (list (cons component-document postcondition)))]
     [(not (equal?  (length (node-children list-box)) 4))
-     (eprintf "Warning: ~a has to few elements to do an induction over. Generating new elements based on what is in the list, this may break something depending on your proof\n" (node-get* list-box ':name))
+     (eprintf "Warning: Generating new elements for inductive component ~a.\n" name)
      (let loop ()
        (if (>= (length (node-children list-box)) 4)
 	 (void)

--- a/src/modularize.rkt
+++ b/src/modularize.rkt
@@ -41,10 +41,15 @@
 
 ;; Produces the documents and problems for the different cases of a proof by induction and returns a list of those cases based on the input document and pre and post conditions
 (define (inductive-cases component-document precondition postcondition)
+  (define base-dom (parse-dom component-document))
+  (define base-box (dom-boxes base-dom))
+  (define base-elt (dom-box->elt base-dom base-box))
+  (define base2-dom (parse-dom component-document))
+  (define base2-box (dom-boxes base2-dom))
+  (define base2-elt (dom-box->elt base2-dom base2-box))
   (define thm-box (parse-tree (dom-boxes component-document)))
   (define ind-dom (parse-dom component-document))
   (define ind-box (dom-boxes ind-dom))
-  (define ind-elts (dom-elements ind-dom))
   ;;If the list has an inductive fact and it has 4 or more elements, set up a proof by induction
   (cond
     ;;When no induction is requested, do nothing
@@ -60,7 +65,43 @@
      (begin
        (eprintf "Found inductive fact ~a\n" (node-get* thm-box ':inductive-fact))
        ;;Create the document/proof for the base case
+       ;;Name the inductive base
+;       (node-set! (node-next (node-fchild base-box)) ':name 'inductive-base)
+       ;;Remove the nodes that arent the first, last, or inductive base form the lisit
+;       (for ([child (node-children base-box)]
+;	    #:unless (or (equal? child (node-fchild base-box)) (equal? child (node-next (node-fchild base-box))) (equal? child (node-lchild base-box))))
+;		(delete-node! child))
+;       (for ([child-elt (node-children base-elt)]
+;	    #:unless (or (equal? child-elt (node-fchild base-elt)) (equal? child-elt (node-next (node-fchild base-elt))) (equal? child-elt (node-lchild base-elt))))
+;		(delete-node! child-elt))
+       ;;Reconstruct the proof to fit the inductive fact into the set of pre conditions
+;       (match-define (list `(forall (,base-varss ...) (=> ,base-press ... ,base-posts)) ...) postcondition)
+ ;      (define base-test 
+;	 (for/list ([base-vars base-varss] [base-pres base-press] [base-post base-posts])
+;	   `(forall (,@base-vars) (=> ,@base-pres  (let ([inductive-footer inductive-base] [inductive-header inductive-base]) ,@(node-get* base-box ':inductive-fact))))))
        ;;Create the document/proof for the base2 case
+       ;;Add the relevant tags to the list boxes
+       (node-set! (node-prev (node-lchild base2-box)) ':no-next #t)
+       (node-set! (node-lchild base2-box) ':no-prev #t)
+       ;;Name the inductive base
+       (node-set! (node-next (node-fchild base2-box)) ':name 'inductive-baseA)
+       (node-set! (node-prev (node-lchild base2-box)) ':name 'inductive-baseB)
+       ;;Remove the nodes that arent the first, last, or inductive base form the lisit
+       (pretty-print (node-children base2-box))
+       (for ([child2 (node-children base2-box)]
+	    #:unless (or (equal? child2 (node-fchild base2-box)) (equal? child2 (node-next (node-fchild base2-box))) (equal? child2 (node-prev (node-lchild base2-box))) (equal? child2 (node-lchild base2-box))))
+		(delete-node! child2))
+       (pretty-print (node-children base2-box))
+       (pretty-print (node-children base2-elt))
+       (for ([child2-elt (node-children base2-elt)]
+	    #:unless (or (equal? child2-elt (node-fchild base2-elt)) (equal? child2-elt (node-next (node-fchild base2-elt))) (equal? child2-elt (node-prev (node-lchild base2-elt))) (equal? child2-elt (node-lchild base2-elt))))
+		(delete-node! child2-elt))
+       (pretty-print (node-children base2-elt))
+       ;;Reconstruct the proof to fit the inductive fact into the set of pre conditions
+       (match-define (list `(forall (,base2-varss ...) (=> ,base2-press ... ,base2-posts)) ...) postcondition)
+       (define base2-test 
+	 (for/list ([base2-vars base2-varss] [base2-pres base2-press] [base2-post base2-posts])
+	   `(forall (,@base2-vars) (=> ,@base2-pres  (let ([inductive-footer inductive-baseB] [inductive-header inductive-baseA]) ,@(node-get* base2-box ':inductive-fact))))))
        ;;Create the document/proof for the thm case
        ;;Add the proper tags to the inductive header, inductive footer, and end of the list to get the correct inductive behaviour from Cassius
 ;       (node-set! (node-next (node-fchild thm-box)) ':no-next #t)
@@ -75,34 +116,30 @@
 ;	   `(forall (,@thm-vars) (=> ,@thm-pres ,@(node-get* thm-box ':inductive-fact) ,thm-post))))
        ;;Create the document/proof for the ind case
        ;;Create and add the node for the inductive-step
-       (pretty-print (node-children ind-box))
-       (define ind-clone (clone-node (node-prev (node-lchild ind-box))))
-       (add-node-before! (node-prev (node-lchild ind-box)) ind-clone)
-      ; (pretty-print ind-elts)
-       (pretty-print (node-children (node-fchild (node-lchild ind-elts))))
-       (define ind-elt-clone (clone-node (node-prev (node-lchild (dom-box->elt ind-dom ind-box)))))
-       (add-node-before! (node-prev (node-lchild (dom-box->elt ind-dom ind-box))) ind-elt-clone)
-       (pretty-print (node-children (node-fchild (node-lchild ind-elts))))
-       (node-set! (node-prev (node-prev (node-lchild ind-box))) ':elt (node-id ind-elt-clone))
+;       (define ind-clone (clone-node (node-prev (node-lchild ind-box))))
+;       (add-node-before! (node-prev (node-lchild ind-box)) ind-clone)
+;       (define ind-elt-clone (clone-node (node-prev (node-lchild (dom-box->elt ind-dom ind-box)))))
+;       (add-node-before! (node-prev (node-lchild (dom-box->elt ind-dom ind-box))) ind-elt-clone)
+;       (node-set! (node-prev (node-prev (node-lchild ind-box))) ':elt (node-id ind-elt-clone))
        ;;Add the proper tags to the inductive header, inductive footer, and end of the list to get the correct inductive behaviour from Cassius
-       (node-set! (node-next (node-fchild ind-box)) ':no-next #t)
-       (node-set! (node-prev (node-prev (node-lchild ind-box))) ':no-prev #t)
-       (node-set! (node-prev (node-lchild ind-box)) ':no-next #t)
-       (node-set! (node-lchild ind-box) ':no-prev #t)
+;       (node-set! (node-next (node-fchild ind-box)) ':no-next #t)
+;       (node-set! (node-prev (node-prev (node-lchild ind-box))) ':no-prev #t)
+;       (node-set! (node-prev (node-lchild ind-box)) ':no-next #t)
+;       (node-set! (node-lchild ind-box) ':no-prev #t)
        ;;Name the inductive header, step, and footer
-       (node-set! (node-next (node-fchild ind-box)) ':name 'inductive-header)
-       (node-set! (node-prev (node-prev (node-lchild ind-box))) ':name 'inductive-footer)
-       (node-set! (node-prev (node-lchild ind-box)) ':name 'inductive-step)
-       (pretty-print (node-children ind-box))
+;       (node-set! (node-next (node-fchild ind-box)) ':name 'inductive-header)
+;       (node-set! (node-prev (node-prev (node-lchild ind-box))) ':name 'inductive-footer)
+;       (node-set! (node-prev (node-lchild ind-box)) ':name 'inductive-step)
        ;;Reconstruct the proof to fit the inductive fact into the set of pre conditions
-       (match-define (list `(forall (,ind-varss ...) (=> ,ind-press ... ,ind-posts)) ...) postcondition)
-       (define ind-test 
-	 (for/list ([ind-vars ind-varss] [ind-pres ind-press] [ind-post ind-posts])
-	   `(forall (,@ind-vars) (=> ,@ind-pres ,@(node-get* ind-box ':inductive-fact) (let ([inductive-footer inductive-step]) ,@(node-get* ind-box ':inductive-fact))))))
-	(pretty-print ind-test)
+;       (match-define (list `(forall (,ind-varss ...) (=> ,ind-press ... ,ind-posts)) ...) postcondition)
+;       (define ind-test 
+;	 (for/list ([ind-vars ind-varss] [ind-pres ind-press] [ind-post ind-posts])
+;	   `(forall (,@ind-vars) (=> ,@ind-pres ,@(node-get* ind-box ':inductive-fact) (let ([inductive-footer inductive-step]) ,@(node-get* ind-box ':inductive-fact))))))
        ;;Return a list of the documents of each of the cases
-       (list #|(cons (struct-copy dom component-document [boxes (unparse-tree thm-box)]) thm-test)|#
-	     (cons (unparse-dom ind-dom) ind-test)))]))
+       (list #|(cons (unparse-dom base-dom) base-test)|#
+	     (cons (unparse-dom base2-dom) base2-test)
+	     #|(cons (struct-copy dom component-document [boxes (unparse-tree thm-box)]) thm-test)|#
+	     #|(cons (unparse-dom ind-dom) ind-test)|#))]))
 
 (define (modularize problem)
   (define fonts (dict-ref problem ':fonts))

--- a/src/modularize.rkt
+++ b/src/modularize.rkt
@@ -38,105 +38,128 @@
       [_
        (cons (first tree) children*)]))
   out)
+;;For Inductive proofs create the problem for the case where the list is 3 items long
+(define (three-case component-document precondition postcondition ind-fact)
+  (define three-dom (parse-dom component-document))
+  (define three-box (dom-boxes three-dom))
+  (define three-elt (dom-box->elt three-dom three-box))
+  (node-set! (node-next (node-fchild three-box)) ':name 'inductive-base)
+  ;;Remove the nodes that arent the first, last, or inductive base form the lisit
+  (for ([child (node-children three-box)]
+    #:unless (or (equal? child (node-fchild three-box)) (equal? child (node-next (node-fchild three-box))) (equal? child (node-lchild three-box))))
+	(delete-node! child))
+  (for ([child-elt (node-children three-elt)]
+    #:unless (or (equal? child-elt (node-fchild three-elt)) (equal? child-elt (node-next (node-fchild three-elt))) (equal? child-elt (node-lchild three-elt))))
+	(delete-node! child-elt))
+       ;;Reconstruct the proof to fit the inductive fact into the set of pre conditions
+  (match-define (list `(forall (,three-varss ...) (=> ,three-press ... ,three-posts)) ...) postcondition)
+  (define three-test 
+    (for/list ([three-vars three-varss] [three-pres three-press] [three-post three-posts])
+     `(forall (,@three-vars) (=> ,@three-pres  (let ([inductive-footer inductive-base] [inductive-header inductive-base]) ,@ind-fact)))))
+  (cons (unparse-dom three-dom) three-test))
 
-;; Produces the documents and problems for the different cases of a proof by induction and returns a list of those cases based on the input document and pre and post conditions
-(define (inductive-cases component-document precondition postcondition)
+;;For inductive proofs create the problem for the base case
+(define (base-case component-document precondition postcondition ind-fact) 
   (define base-dom (parse-dom component-document))
   (define base-box (dom-boxes base-dom))
   (define base-elt (dom-box->elt base-dom base-box))
-  (define base2-dom (parse-dom component-document))
-  (define base2-box (dom-boxes base2-dom))
-  (define base2-elt (dom-box->elt base2-dom base2-box))
-  (define thm-box (parse-tree (dom-boxes component-document)))
+  (node-set! (node-prev (node-lchild base-box)) ':no-next #t)
+  (node-set! (node-lchild base-box) ':no-prev #t)
+  ;;Name the inductive base
+  (node-set! (node-next (node-fchild base-box)) ':name 'inductive-baseA)
+  (node-set! (node-prev (node-lchild base-box)) ':name 'inductive-baseB)
+  ;;Remove the nodes that arent the first, last, or inductive base form the lisit
+  (for ([child (node-children base-box)]
+    #:unless (or (equal? child (node-fchild base-box)) (equal? child (node-next (node-fchild base-box))) (equal? child (node-prev (node-lchild base-box))) (equal? child (node-lchild base-box))))
+	(delete-node! child))
+  (for ([child-elt (node-children base-elt)]
+    #:unless (or (equal? child-elt (node-fchild base-elt)) (equal? child-elt (node-next (node-fchild base-elt))) (equal? child-elt (node-prev (node-lchild base-elt))) (equal? child-elt (node-lchild base-elt))))
+	(delete-node! child-elt))
+  ;;Reconstruct the proof to fit the inductive fact into the set of pre conditions
+  (match-define (list `(forall (,base-varss ...) (=> ,base-press ... ,base-posts)) ...) postcondition)
+  (define base-test 
+    (for/list ([base-vars base-varss] [base-pres base-press] [base-post base-posts])
+     `(forall (,@base-vars) (=> ,@base-pres  (let ([inductive-footer inductive-baseB] [inductive-header inductive-baseA]) ,@ind-fact)))))
+  (cons (unparse-dom base-dom) base-test))
+
+;;For inductive proofs create the problem for the ind case
+(define (ind-case component-document precondition postcondition ind-fact)
   (define ind-dom (parse-dom component-document))
   (define ind-box (dom-boxes ind-dom))
-  (define ind-fact (node-get* thm-box ':inductive-fact))
+  (define ind-elt (dom-box->elt ind-dom ind-box))
+  (define ind-clone (clone-node (node-prev (node-lchild ind-box))))
+  (add-node-before! (node-prev (node-lchild ind-box)) ind-clone)
+  (define ind-elt-clone (clone-node (node-prev (node-lchild (dom-box->elt ind-dom ind-box)))))
+  (add-node-before! (node-prev (node-lchild (dom-box->elt ind-dom ind-box))) ind-elt-clone)
+  (node-set! (node-prev (node-prev (node-lchild ind-box))) ':elt (node-id ind-elt-clone))
+  ;;Add the proper tags to the inductive header, inductive footer, and end of the list to get the correct inductive behaviour from Cassius
+  (node-set! (node-next (node-fchild ind-box)) ':no-next #t)
+  (node-set! (node-prev (node-prev (node-lchild ind-box))) ':no-prev #t)
+  (node-set! (node-prev (node-lchild ind-box)) ':no-next #t)
+  (node-set! (node-lchild ind-box) ':no-prev #t)
+  ;;Name the inductive header, step, and footer
+  (node-set! (node-next (node-fchild ind-box)) ':name 'inductive-header)
+  (node-set! (node-prev (node-prev (node-lchild ind-box))) ':name 'inductive-footer)
+  (node-set! (node-prev (node-lchild ind-box)) ':name 'inductive-step)
+  ;;Reconstruct the proof to fit the inductive fact into the set of pre conditions
+  (match-define (list `(forall (,ind-varss ...) (=> ,ind-press ... ,ind-posts)) ...) postcondition)
+  (define ind-test 
+    (for/list ([ind-vars ind-varss] [ind-pres ind-press] [ind-post ind-posts])
+      `(forall (,@ind-vars) (=> ,@ind-pres ,@ind-fact (let ([inductive-footer inductive-step]) ,@ind-fact)))))
+  (cons (unparse-dom ind-dom) ind-test))
+
+;;For inductive proofs create the problem for the thm case
+(define (thm-case component-document precondition postcondition ind-fact)
+  (define thm-dom (parse-dom component-document))
+  (define thm-box (dom-boxes thm-dom))
+  (node-set! (node-next (node-fchild thm-box)) ':no-next #t)
+  (node-set! (node-prev (node-lchild thm-box)) ':no-prev #t)
+  ;;Name the inductive header and footer
+  (node-set! (node-next (node-fchild thm-box)) ':name 'inductive-header)
+  (node-set! (node-prev (node-lchild thm-box)) ':name 'inductive-footer)
+  ;;Reconstruct the proof to fit the inductive fact into the set of pre conditions
+  (match-define (list `(forall (,thm-varss ...) (=> ,thm-press ... ,thm-posts)) ...) postcondition)
+  (define thm-test 
+    (for/list ([thm-vars thm-varss] [thm-pres thm-press] [thm-post thm-posts])
+      `(forall (,@thm-vars) (=> ,@thm-pres ,@ind-fact ,thm-post))))
+  (cons (unparse-dom thm-dom) thm-test))
+
+;; Produces the documents and problems for the different cases of a proof by induction and returns a list of those cases based on the input document and pre and post conditions
+(define (inductive-cases component-document precondition postcondition)
+  (define list-dom (parse-dom component-document))
+  (define list-box (dom-boxes list-dom))
+  (define list-elt (dom-box->elt list-dom list-box))
+  (define ind-fact (node-get* list-box ':inductive-fact))
   ;;If the list has an inductive fact and it has 4 or more elements, set up a proof by induction
   (cond
     ;;When no induction is requested, do nothing
     [(not ind-fact)
      (list (cons component-document postcondition))]
-    ;;When induction is requested, but the list given doesn't have at leaste for elements, print out a warning and do nothing
-    [(and (< (length (node-children thm-box)) 4) ind-fact)
+    ;;When induction is requested, but the list given is empty, print out a warning and do nothing
+    [(and (= (length (node-children list-box)) 0) ind-fact)
     (begin
-       (eprintf "Warning: ~a is to small to induct over on page one of the given pages. ~a Must have at least 4 elements. Skipping induction for ~a\n"   (node-get* thm-box ':name) (node-get* thm-box ':name) (node-get* thm-box ':name))
+       (eprintf "Warning: ~a is Empty, and can not be inducted over. Cassius induction requires that  ~a  have at least 1 element. Skipping induction for ~a\n"   (node-get* list-box ':name) (node-get* list-box ':name) (node-get* list-box ':name))
        (list (cons component-document postcondition)))]
+    [(< 0  (length (node-children list-box)) 4)
+     (eprintf "Warning: ~a has to few elements to do an induction over. Generating new elements based on what is in the list, this may break something depending on your proof\n" (node-get* list-box ':name))
+     (let loop ()
+       (if (>= (length (node-children list-box)) 4)
+	 (void)
+       	 (let ([box-clone (clone-node (node-lchild list-box))]
+               [elt-clone (clone-node (node-lchild list-elt))])
+           (add-node-before! (node-lchild list-box) box-clone)
+           (add-node-before! (node-lchild (dom-box->elt list-dom list-box)) elt-clone)
+           (node-set! box-clone ':elt (node-id elt-clone))
+	   (loop))))
+     (inductive-cases (unparse-dom list-dom) precondition postcondition)]
     ;;When induction is requested and the list given has at least 4 elements create and return the list of cases for induction
-     [(and (>= (length (node-children thm-box)) 4) ind-fact)
-     (begin
-       (eprintf "Found inductive fact ~a\n" ind-fact)
-       ;;Create the document/proof for the base case
-       ;;Name the inductive base
-       (node-set! (node-next (node-fchild base-box)) ':name 'inductive-base)
-       ;;Remove the nodes that arent the first, last, or inductive base form the lisit
-       (for ([child (node-children base-box)]
-	    #:unless (or (equal? child (node-fchild base-box)) (equal? child (node-next (node-fchild base-box))) (equal? child (node-lchild base-box))))
-		(delete-node! child))
-       (for ([child-elt (node-children base-elt)]
-	    #:unless (or (equal? child-elt (node-fchild base-elt)) (equal? child-elt (node-next (node-fchild base-elt))) (equal? child-elt (node-lchild base-elt))))
-		(delete-node! child-elt))
-       ;;Reconstruct the proof to fit the inductive fact into the set of pre conditions
-       (match-define (list `(forall (,base-varss ...) (=> ,base-press ... ,base-posts)) ...) postcondition)
-       (define base-test 
-	 (for/list ([base-vars base-varss] [base-pres base-press] [base-post base-posts])
-	   `(forall (,@base-vars) (=> ,@base-pres  (let ([inductive-footer inductive-base] [inductive-header inductive-base]) ,@ind-fact)))))
-       ;;Create the document/proof for the base2 case
-       ;;Add the relevant tags to the list boxes
-       (node-set! (node-prev (node-lchild base2-box)) ':no-next #t)
-       (node-set! (node-lchild base2-box) ':no-prev #t)
-       ;;Name the inductive base
-       (node-set! (node-next (node-fchild base2-box)) ':name 'inductive-baseA)
-       (node-set! (node-prev (node-lchild base2-box)) ':name 'inductive-baseB)
-       ;;Remove the nodes that arent the first, last, or inductive base form the lisit
-       (for ([child2 (node-children base2-box)]
-	    #:unless (or (equal? child2 (node-fchild base2-box)) (equal? child2 (node-next (node-fchild base2-box))) (equal? child2 (node-prev (node-lchild base2-box))) (equal? child2 (node-lchild base2-box))))
-		(delete-node! child2))
-       (for ([child2-elt (node-children base2-elt)]
-	    #:unless (or (equal? child2-elt (node-fchild base2-elt)) (equal? child2-elt (node-next (node-fchild base2-elt))) (equal? child2-elt (node-prev (node-lchild base2-elt))) (equal? child2-elt (node-lchild base2-elt))))
-		(delete-node! child2-elt))
-       ;;Reconstruct the proof to fit the inductive fact into the set of pre conditions
-       (match-define (list `(forall (,base2-varss ...) (=> ,base2-press ... ,base2-posts)) ...) postcondition)
-       (define base2-test 
-	 (for/list ([base2-vars base2-varss] [base2-pres base2-press] [base2-post base2-posts])
-	   `(forall (,@base2-vars) (=> ,@base2-pres  (let ([inductive-footer inductive-baseB] [inductive-header inductive-baseA]) ,@ind-fact)))))
-       ;;Create the document/proof for the thm case
-       ;;Add the proper tags to the inductive header, inductive footer, and end of the list to get the correct inductive behaviour from Cassius
-       (node-set! (node-next (node-fchild thm-box)) ':no-next #t)
-       (node-set! (node-prev (node-lchild thm-box)) ':no-prev #t)
-       ;;Name the inductive header and footer
-       (node-set! (node-next (node-fchild thm-box)) ':name 'inductive-header)
-       (node-set! (node-prev (node-lchild thm-box)) ':name 'inductive-footer)
-       ;;Reconstruct the proof to fit the inductive fact into the set of pre conditions
-       (match-define (list `(forall (,thm-varss ...) (=> ,thm-press ... ,thm-posts)) ...) postcondition)
-       (define thm-test 
-	 (for/list ([thm-vars thm-varss] [thm-pres thm-press] [thm-post thm-posts])
-	   `(forall (,@thm-vars) (=> ,@thm-pres ,@ind-fact ,thm-post))))
-       ;;Create the document/proof for the ind case
-       ;;Create and add the node for the inductive-step
-       (define ind-clone (clone-node (node-prev (node-lchild ind-box))))
-       (add-node-before! (node-prev (node-lchild ind-box)) ind-clone)
-       (define ind-elt-clone (clone-node (node-prev (node-lchild (dom-box->elt ind-dom ind-box)))))
-       (add-node-before! (node-prev (node-lchild (dom-box->elt ind-dom ind-box))) ind-elt-clone)
-       (node-set! (node-prev (node-prev (node-lchild ind-box))) ':elt (node-id ind-elt-clone))
-       ;;Add the proper tags to the inductive header, inductive footer, and end of the list to get the correct inductive behaviour from Cassius
-       (node-set! (node-next (node-fchild ind-box)) ':no-next #t)
-       (node-set! (node-prev (node-prev (node-lchild ind-box))) ':no-prev #t)
-       (node-set! (node-prev (node-lchild ind-box)) ':no-next #t)
-       (node-set! (node-lchild ind-box) ':no-prev #t)
-       ;;Name the inductive header, step, and footer
-       (node-set! (node-next (node-fchild ind-box)) ':name 'inductive-header)
-       (node-set! (node-prev (node-prev (node-lchild ind-box))) ':name 'inductive-footer)
-       (node-set! (node-prev (node-lchild ind-box)) ':name 'inductive-step)
-       ;;Reconstruct the proof to fit the inductive fact into the set of pre conditions
-       (match-define (list `(forall (,ind-varss ...) (=> ,ind-press ... ,ind-posts)) ...) postcondition)
-       (define ind-test 
-	 (for/list ([ind-vars ind-varss] [ind-pres ind-press] [ind-post ind-posts])
-	   `(forall (,@ind-vars) (=> ,@ind-pres ,@ind-fact (let ([inductive-footer inductive-step]) ,@ind-fact)))))
-       ;;Return a list of the documents of each of the cases
-       (list (cons (unparse-dom base-dom) base-test)
-	     (cons (unparse-dom base2-dom) base2-test)
-	     (cons (struct-copy dom component-document [boxes (unparse-tree thm-box)]) thm-test)
-	     (cons (unparse-dom ind-dom) ind-test)))]))
+    [(>= (length (node-children list-box)) 4)
+     (eprintf "Found inductive fact ~a\n" ind-fact)
+     ;;Return a list of the documents of each of the cases
+     (list   (three-case component-document precondition postcondition ind-fact)
+	     (base-case component-document precondition postcondition ind-fact)
+	     (thm-case component-document precondition postcondition ind-fact)
+	     (ind-case component-document precondition postcondition ind-fact))]))
 
 (define (modularize problem)
   (define fonts (dict-ref problem ':fonts))

--- a/src/modularize.rkt
+++ b/src/modularize.rkt
@@ -42,7 +42,6 @@
 ;; Produces the documents and problems for the different cases of a proof by induction and returns a list of those cases based on the input document and pre and post conditions
 (define (inductive-cases component-document precondition postcondition)
   (define thm-box (parse-tree (dom-boxes component-document)))
-  (pretty-print thm-box)
   ;;If the list has an inductive fact and it has 4 or more elements, set up a proof by induction
   (cond
     ;;When no induction is requested, do nothing
@@ -61,16 +60,22 @@
        ;;Create the document/proof for the base2 case
        ;;Create the document/proof for the thm case
        ;;Add the proper tags to the inductive header, inductive footer, and end of the list to get the correct inductive behaviour from Cassius
-       (node-set*! (node-next (node-fchild thm-box)) ':no-next #t)
-       (node-set*! (node-prev (node-lchild thm-box)) ':no-prev-or-next #t)
-       (node-set*! (node-lchild thm-box) ':no-prev #t)
+       (node-set! (node-next (node-fchild thm-box)) ':no-next #t)
+       (node-set! (node-prev (node-lchild thm-box)) ':no-prev #t)
        ;;Name the inductive header and footer
-       (node-set*! (node-next (node-fchild thm-box)) ':name "inductive-header")
-       (node-set*! (node-prev (node-lchild thm-box)) ':name "inductive-footer")
+       (node-set! (node-next (node-fchild thm-box)) ':name 'inductive-header)
+       (node-set! (node-prev (node-lchild thm-box)) ':name 'inductive-footer)
+       (pretty-print (node-next (node-fchild thm-box)))
+       (pretty-print (node-prev (node-lchild thm-box)))
        ;;Reconstruct the proof to fit the inductive fact into the set of pre conditions
-       (pretty-print postcondition)
+       (match-define (list `(forall (,varss ...) (=> ,press ... ,posts)) ...) postcondition)
+       (define thm-test 
+	 (for/list ([vars varss] [pres press] [post posts])
+	   `(forall (,@vars) (=> ,@pres ,@(node-get* thm-box ':inductive-fact) ,post))))
+       (pretty-print thm-test)
        ;;Create the document/proof for the ind case
-       (list (cons component-document postcondition)))]))
+       ;;Return a list of the documents of each of the cases
+       (list (cons (unparse-tree thm-box) thm-test)))]))
 
 (define (modularize problem)
   (define fonts (dict-ref problem ':fonts))

--- a/src/modularize.rkt
+++ b/src/modularize.rkt
@@ -41,7 +41,12 @@
 
 ;;For Inductive proofs create the problem for the case where the list is 3 items long
 (define (one-case component-document precondition postcondition ind-fact)
-  (define one-dom (parse-dom component-document))
+  (define one-dom-old-name (parse-dom component-document))
+  (define old-name (dom-name one-dom-old-name))
+  (define new-name (sformat "~a.one-case" old-name))
+  (define one-dom 
+    (struct-copy dom one-dom-old-name
+  	         [name new-name]))
   (define one-box (dom-boxes one-dom))
   (define one-elt (dom-box->elt one-dom one-box))
   ;;Remove the nodes that arent the first, last, or inductive base form the lisit
@@ -51,12 +56,16 @@
   (for ([child-elt (node-children one-elt)]
     #:unless (equal? child-elt (node-fchild one-elt)))
 	(delete-node! child-elt))
-       ;;Reconstruct the proof to fit the inductive fact into the set of pre conditions
   (cons (unparse-dom one-dom) postcondition))
 
 ;;For Inductive proofs create the problem for the case where the list is 3 items long
 (define (two-case component-document precondition postcondition ind-fact)
-  (define two-dom (parse-dom component-document))
+  (define two-dom-old-name (parse-dom component-document))
+  (define old-name (dom-name two-dom-old-name))
+  (define new-name (sformat "~a.two-case" old-name))
+  (define two-dom
+    (struct-copy dom two-dom-old-name
+		 [name new-name]))
   (define two-box (dom-boxes two-dom))
   (define two-elt (dom-box->elt two-dom two-box))
   (node-set! (node-next (node-fchild two-box)) ':name 'inductive-base)
@@ -71,7 +80,12 @@
 
 ;;For Inductive proofs create the problem for the case where the list is 3 items long
 (define (three-case component-document precondition postcondition ind-fact)
-  (define three-dom (parse-dom component-document))
+  (define three-dom-old-name (parse-dom component-document))
+  (define old-name (dom-name three-dom-old-name))
+  (define new-name (sformat "~a.three-case" old-name))
+  (define three-dom
+    (struct-copy dom three-dom-old-name
+		 [name new-name]))
   (define three-box (dom-boxes three-dom))
   (define three-elt (dom-box->elt three-dom three-box))
   (node-set! (node-next (node-fchild three-box)) ':name 'inductive-base)
@@ -91,7 +105,12 @@
 
 ;;For inductive proofs create the problem for the base case
 (define (base-case component-document precondition postcondition ind-fact) 
-  (define base-dom (parse-dom component-document))
+  (define base-dom-old-name (parse-dom component-document))
+  (define old-name (dom-name base-dom-old-name))
+  (define new-name (sformat "~a.base-case" old-name))
+  (define base-dom
+    (struct-copy dom base-dom-old-name
+		 [name new-name]))
   (define base-box (dom-boxes base-dom))
   (define base-elt (dom-box->elt base-dom base-box))
   (node-set! (node-prev (node-lchild base-box)) ':no-next #t)
@@ -115,7 +134,12 @@
 
 ;;For inductive proofs create the problem for the ind case
 (define (ind-case component-document precondition postcondition ind-fact)
-  (define ind-dom (parse-dom component-document))
+  (define ind-dom-old-name (parse-dom component-document))
+  (define old-name (dom-name ind-dom-old-name))
+  (define new-name (sformat "~a.inductive-step" old-name))
+  (define ind-dom
+    (struct-copy dom ind-dom-old-name
+		[name new-name]))
   (define ind-box (dom-boxes ind-dom))
   (define ind-elt (dom-box->elt ind-dom ind-box))
   (define ind-clone (clone-node (node-prev (node-lchild ind-box))))
@@ -141,7 +165,12 @@
 
 ;;For inductive proofs create the problem for the thm case
 (define (thm-case component-document precondition postcondition ind-fact)
-  (define thm-dom (parse-dom component-document))
+  (define thm-dom-old-name (parse-dom component-document))
+  (define old-name (dom-name thm-dom-old-name))
+  (define new-name (sformat "~a.theorem" old-name))
+  (define thm-dom
+    (struct-copy dom thm-dom-old-name
+		 [name new-name]))
   (define thm-box (dom-boxes thm-dom))
   (node-set! (node-next (node-fchild thm-box)) ':no-next #t)
   (node-set! (node-prev (node-lchild thm-box)) ':no-prev #t)

--- a/src/modularize.rkt
+++ b/src/modularize.rkt
@@ -39,10 +39,21 @@
        (cons (first tree) children*)]))
   out)
 
+;; Produces the documents and problems for the different cases of a proof by induction and returns a list of those cases based on the input document and pre and post conditions
+(define (inductive-cases component-document precondition postcondition)
+  (define component-box (parse-tree (dom-boxes component-document)))
+  (if (node-get* component-box ':inductive-fact)
+    (begin
+      (eprintf "Found inductive fact ~a\n" (node-get* component-box ':inductive-fact))
+      (list (cons component-document postcondition)))
+    (list (cons component-document postcondition))))
+
 (define (modularize problem)
   (define fonts (dict-ref problem ':fonts))
   (define sheets (dict-ref problem ':sheets))
-  (for*/list ([doc (dict-ref problem ':documents)] [(name thing) (split-document doc)]
+  (for*/list ([doc (dict-ref problem ':documents)] 
+	      [(name thing) (split-document doc)]
+	      [cases (inductive-cases (car thing) 'todo-no-precondition (cdr thing))]
               #:unless (null? (cdr thing)))
     (match-define (cons piece specs) thing)
     (define problem*

--- a/src/modularize.rkt
+++ b/src/modularize.rkt
@@ -180,7 +180,7 @@
 
     ;;When induction is requested, but the list given is empty, print out a warning and do nothing
     [(and (= (length (node-children list-box)) 0) ind-fact)
-     (eprintf "Warning: Cannot induct over empty component ~a. Proving ~a directly\n" name name name)
+     (eprintf "Warning: Cannot induct over empty component ~a. Proving ~a directly\n" name name)
      (list (cons component-document postcondition))]
     [(< (length (node-children list-box)) 4)
      (eprintf "Warning: Generating new elements for inductive component ~a.\n" name)

--- a/src/modularize.rkt
+++ b/src/modularize.rkt
@@ -170,7 +170,7 @@
   (define list-box (dom-boxes list-dom))
   (define list-elt (dom-box->elt list-dom list-box))
   (define ind-fact (node-get* list-box ':inductive-fact))
-  (define name (node-get list'box ':name))
+  (define name (node-get list-box ':name))
 
   ;;If the list has an inductive fact and it has 4 or more elements, set up a proof by induction
   (cond

--- a/src/proofs.rkt
+++ b/src/proofs.rkt
@@ -82,7 +82,7 @@
       [`(induct ,name ,inductive-fact)
 	(define boxes (box-set name box-context))
 	(for* ([box (in-list boxes)])
-	(node-set! box ':induct inductive-fact))]
+	(node-set! box ':inductive-fact inductive-fact))]
 	
       ;;Given a name and type of value this command erases all values of that type from the component with the given name
       [`(erase ,name ,type)

--- a/src/proofs.rkt
+++ b/src/proofs.rkt
@@ -82,7 +82,9 @@
       [`(induct ,name ,inductive-fact)
 	(define boxes (box-set name box-context))
 	(for* ([box (in-list boxes)])
-	(node-set! box ':inductive-fact inductive-fact))]
+	      (when (node-get box ':inductive-fact)
+		(raise (format "~a can not be inducted over more than once" box)))
+	      (node-set! box ':inductive-fact inductive-fact))]
 	
       ;;Given a name and type of value this command erases all values of that type from the component with the given name
       [`(erase ,name ,type)

--- a/src/proofs.rkt
+++ b/src/proofs.rkt
@@ -81,7 +81,8 @@
       ;;Add the relevant tags to the input box to get modularize to correctly create the setup for a proof by induction
       [`(induct ,name ,inductive-fact)
 	(define boxes (box-set name box-context))
-	(node-set! box ':induct inductive-fact)]
+	(for* ([box (in-list boxes)])
+	(node-set! box ':induct inductive-fact))]
 	
       ;;Given a name and type of value this command erases all values of that type from the component with the given name
       [`(erase ,name ,type)

--- a/src/proofs.rkt
+++ b/src/proofs.rkt
@@ -78,7 +78,11 @@
          (node-set*! box ':spec (list))
          (node-set! box ':split (length (hash-ref box-context '*)))
          (hash-update! box-context '* (curry cons box)))]
-
+      ;;Add the relevant tags to the input box to get modularize to correctly create the setup for a proof by induction
+      [`(induct ,name ,inductive-fact)
+	(define boxes (box-set name box-context))
+	(node-set! box ':induct inductive-fact)]
+	
       ;;Given a name and type of value this command erases all values of that type from the component with the given name
       [`(erase ,name ,type)
        (define boxes (box-set name box-context))

--- a/src/spec/tree.rkt
+++ b/src/spec/tree.rkt
@@ -72,9 +72,5 @@
   
    (define-fun link-box-no-prev  ((box Box) (p Box) (v Box) (n Box) (f Box) (l Box)) Bool
     (and (= (pbox box) p) (= (nbox box) n)))
-
-   (define-fun link-box-no-next-or-prev  ((box Box) (p Box) (v Box) (n Box) (f Box) (l Box)) Bool
-    (and (= (pbox box) p)))
-
   )
 


### PR DESCRIPTION
Now that internal support for induction has been implemented changes are needed to the outer wrapper of Cassius to make it so a user could tell the tool to do such a proof. To this end the following changes must me made
- [x] Alter proofs.rkt to include a new tactic that does a proof by induction
- [x] Alter modularize.rkt to create the problems expected by the internals in the case of a inductive proof

Timing results for a simple todo list web page:

|           | real | user | sys |
| ------- | --- | --- | --- |
| Old way | 2m54s | 1m46s | 57s |
| (erase) | 47s | 32s | 12s |
| (induct) | 39s | 25s | 11s |

That gap should continue growing as the page gets bigger.