### PR TITLE
Create an append-list proof strategy

### DIFF
--- a/bench/append.proof
+++ b/bench/append.proof
@@ -4,7 +4,7 @@
 
 (import "common.thm")
 
-(page press-0 (load "induction.rkt" doc-1)
+(page press-0 (load "append-with-js.rkt" list)
       :w (between 800 1920)
       :h (between 600 1280)
       :fs (between 16 32))

--- a/bench/append.proof
+++ b/bench/append.proof
@@ -9,36 +9,14 @@
       :h (between 600 1280)
       :fs (between 16 32))
  
-(page press-1 (load "induction.rkt" doc-2)
-      :w (between 800 1920)
-      :h (between 600 1280)
-      :fs (between 16 32))
- 
-(page press-2 (load "induction.rkt" doc-3)
-      :w (between 800 1920)
-      :h (between 600 1280)
-      :fs (between 16 32))
- 
-(page press-3 (load "induction.rkt" doc-4)
-      :w (between 800 1920)
-      :h (between 600 1280)
-      :fs (between 16 32))
- 
-(page press-4 (load "induction.rkt" doc-5)
-      :w (between 800 1920)
-      :h (between 600 1280)
-      :fs (between 16 32))
- 
-(page press-5 (load "induction.rkt" doc-6)
-      :w (between 800 1920)
-      :h (between 600 1280)
-      :fs (between 16 32))
- 
+(page press-1 (run press-0 (append-child (id list) 
+    [BLOCK]
+    [li]))) 
  
 (theorem (top-above-bottom b)
   (>= (- (bottom b) (top b) 0)))
 
-(proof (top-above-bottom top-above-bottom press-0 press-1 press-2 press-3 press-4 press-5)
+(proof (top-above-bottom top-above-bottom press-1)
   (component list (id list))
   (component button (tag button))
   (components todos (child (id list) *))
@@ -46,14 +24,11 @@
   (erase todos :text)
   (assert todos (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)))
   (pre list (= (floats-tracked ?) 0))
-  (append-list list 
-    [BLOCK :x 48 :y 16 :w 1224 :h 19 :elt 5]
-    ([li :num 5]))  
   (induct list ; the inductive fact
   	(and (>= (- (bottom inductive-footer) (top inductive-header)) 0) (= (floats-tracked inductive-footer) (floats-tracked inductive-header))))
   (assert list (forall () (>= (- (bottom (last list)) (top (first list)) 0)))))
 
-(proof (interactive-onscreen interactive-onscreen press-0 press-1 press-2 press-3)
+(proof (interactive-onscreen interactive-onscreen press-0 press-1)
   (component list (id list))
   (component button (tag button))
   (components todos (child (id list) *))

--- a/bench/append.proof
+++ b/bench/append.proof
@@ -25,10 +25,21 @@
 (page press-5 (run press-4 (append-child (id list) 
     [BLOCK]
     [li]))) 
+
+
+(script add_element
+  (let list (select (id list)))
+  (let elt (create [li]))
+  (set elt ':id "'element-' + (list.children.length + 1) + '/' + window.iteration")
+  (set elt ':text "'value-' + (list.children.length + 1) + '/' + window.iteration")
+  (append-child list elt))
+
+(page press-js (run-js press-0 add_element))
+
 (theorem (top-above-bottom b)
   (>= (- (bottom b) (top b) 0)))
 
-(proof (top-above-bottom top-above-bottom press-1 press-2 press-3 press-4 press-5)
+(proof (top-above-bottom top-above-bottom press-js)
   (component list (id list))
   (component button (tag button))
   (components todos (child (id list) *))

--- a/bench/append.proof
+++ b/bench/append.proof
@@ -1,0 +1,68 @@
+;; -*- mode: scheme -*-
+;; A Proof to verify the functionality of a simple website that uses java script
+;; By Skyler Griffith
+
+(import "common.thm")
+
+(page press-0 (load "induction.rkt" doc-1)
+      :w (between 800 1920)
+      :h (between 600 1280)
+      :fs (between 16 32))
+ 
+(page press-1 (load "induction.rkt" doc-2)
+      :w (between 800 1920)
+      :h (between 600 1280)
+      :fs (between 16 32))
+ 
+(page press-2 (load "induction.rkt" doc-3)
+      :w (between 800 1920)
+      :h (between 600 1280)
+      :fs (between 16 32))
+ 
+(page press-3 (load "induction.rkt" doc-4)
+      :w (between 800 1920)
+      :h (between 600 1280)
+      :fs (between 16 32))
+ 
+(page press-4 (load "induction.rkt" doc-5)
+      :w (between 800 1920)
+      :h (between 600 1280)
+      :fs (between 16 32))
+ 
+(page press-5 (load "induction.rkt" doc-6)
+      :w (between 800 1920)
+      :h (between 600 1280)
+      :fs (between 16 32))
+ 
+ 
+(theorem (top-above-bottom b)
+  (>= (- (bottom b) (top b) 0)))
+
+(proof (top-above-bottom top-above-bottom press-0 press-1 press-2 press-3 press-4 press-5)
+  (component list (id list))
+  (component button (tag button))
+  (components todos (child (id list) *))
+
+  (erase todos :text)
+  (assert todos (and (> (height ?) 0) (float-flow-skip ?) (non-negative-margins ?)))
+  (pre list (= (floats-tracked ?) 0))
+  (append-list list 
+    [BLOCK :x 48 :y 16 :w 1224 :h 19 :elt 5]
+    ([li :num 5]))  
+  (induct list ; the inductive fact
+  	(and (>= (- (bottom inductive-footer) (top inductive-header)) 0) (= (floats-tracked inductive-footer) (floats-tracked inductive-header))))
+  (assert list (forall () (>= (- (bottom (last list)) (top (first list)) 0)))))
+
+(proof (interactive-onscreen interactive-onscreen press-0 press-1 press-2 press-3)
+  (component list (id list))
+  (component button (tag button))
+  (components todos (child (id list) *))
+  (erase todos :text)
+  (assert list 
+    (=> (or (= (prev list) null)
+            (non-negative-margins (prev list)))
+        (non-negative-margins list)))
+  (assert * (forall (b) (=> (onscreen ?)
+  		            (=> (or (is-component b) (is-interactive b)) (onscreen b)))))
+  (assert (- * list) (forall (t) (=> (has-type t text) (> (width t) 0) (non-negative-margins ?))))
+  (assert root (onscreen root)))

--- a/bench/append.proof
+++ b/bench/append.proof
@@ -13,10 +13,22 @@
     [BLOCK]
     [li]))) 
  
+(page press-2 (run press-1 (append-child (id list) 
+    [BLOCK]
+    [li]))) 
+(page press-3 (run press-2 (append-child (id list) 
+    [BLOCK]
+    [li]))) 
+(page press-4 (run press-3 (append-child (id list) 
+    [BLOCK]
+    [li]))) 
+(page press-5 (run press-4 (append-child (id list) 
+    [BLOCK]
+    [li]))) 
 (theorem (top-above-bottom b)
   (>= (- (bottom b) (top b) 0)))
 
-(proof (top-above-bottom top-above-bottom press-1)
+(proof (top-above-bottom top-above-bottom press-1 press-2 press-3 press-4 press-5)
   (component list (id list))
   (component button (tag button))
   (components todos (child (id list) *))
@@ -28,7 +40,7 @@
   	(and (>= (- (bottom inductive-footer) (top inductive-header)) 0) (= (floats-tracked inductive-footer) (floats-tracked inductive-header))))
   (assert list (forall () (>= (- (bottom (last list)) (top (first list)) 0)))))
 
-(proof (interactive-onscreen interactive-onscreen press-0 press-1)
+(proof (interactive-onscreen interactive-onscreen press-0 press-1 press-2 press-3 press-4 press-5)
   (component list (id list))
   (component button (tag button))
   (components todos (child (id list) *))

--- a/bench/induction/list.html
+++ b/bench/induction/list.html
@@ -2,12 +2,11 @@
 <html>
 <script>
 function add_element(e) {
-    let list = document.getElementById("list");
-    let n = list.children.length + 1;
-    let list_element = document.createElement('li');
-    list_element.id = 'element-' + n + '/' + window.iteration;
-    list_element.innerHTML = "value-" + n + '/' + window.iteration;
-    list.appendChild(list_element);
+	var list = document.getElementById("list");
+	var elt = document.createElement('li');
+	elt.id = 'element-' + (list.children.length + 1) + '/' + window.iteration;
+	elt.innerText = 'value-' + (list.children.length + 1) + '/' + window.iteration;
+	list.appendChild(elt);
 }
 </script>
 <body>

--- a/bench/induction/list.html
+++ b/bench/induction/list.html
@@ -2,7 +2,7 @@
 <html>
 <script>
 function add_element(e) {
-	var list = document.getElementById("list");
+	var list = document.querySelector("#list");
 	var elt = document.createElement('li');
 	elt.id = 'element-' + (list.children.length + 1) + '/' + window.iteration;
 	elt.innerText = 'value-' + (list.children.length + 1) + '/' + window.iteration;

--- a/capture/get_bench.ts
+++ b/capture/get_bench.ts
@@ -908,7 +908,8 @@ function dump_document(features) {
             if (elt.tagName.toUpperCase() === "HR" && elt.size) {
                 rec.props["size"] = elt.size;
                 features["hr:size"] = true;
-            }
+	    }
+
 
             for (var i = 0; i < elt.childNodes.length; i++) {
                 if (is_comment(elt.childNodes[i])) continue;
@@ -939,6 +940,15 @@ function annotate_box_elt(box) {
 import { MAX, compute_flt_pointer, check_float_registers } from "./ezone";
 import { dump_fonts } from "./fonts";
 import { dump_browser } from "./browser";
+
+function trim_script(script) {
+    var out = "";
+    var split_script = script.split("\n");
+    for (var i = 0; i < split_script.length; i++) {
+        out += split_script[i].trim() + "\n";
+    }
+    return out;
+}
 
 export function page2text(name) {
     LETTER = name;
@@ -983,6 +993,10 @@ export function page2text(name) {
     text += " ([VIEW :w " + page.props.w + "]";
     text += dump_tree(page.children[0]);
     text += "))\n\n";
+    
+    text += "(define-script " + name +"\n";
+    text += trim_script(dump_string(document.querySelectorAll("script")[0].textContent));
+    text += ")\n\n";
 
     text += "(define-problem " + name;
     text += "\n  :title " + dump_string(document.title);
@@ -990,6 +1004,7 @@ export function page2text(name) {
     text += "\n  :sheets firefox " + name;
     text += "\n  :fonts " + name;
     text += "\n  :layouts " + name;
+    text += "\n  :script " + name;
     if (ERROR) {
         text += "\n  :error " + dump_string(ERROR + "");
         features["unknown-error"] = true;

--- a/src/dom.rkt
+++ b/src/dom.rkt
@@ -3,9 +3,9 @@
 
 (provide (struct-out dom) dom-context in-elements in-boxes parse-dom unparse-dom
          dom-box->elt dom-elt->box dom-first-box? dom-last-box?
-         dom-strip-positions dom-set-range)
+         dom-strip-positions dom-set-range dom-rematch!)
 
-(struct dom (name properties elements boxes match) #:prefab)
+(struct dom (name properties elements boxes match) #:prefab #:mutable)
 
 (define (dom-context dom key #:default [default #f])
   (dict-ref (dom-properties dom) key default))
@@ -25,6 +25,9 @@
                [elements (unparse-tree (dom-elements doc))]
                [boxes (unparse-tree (dom-boxes doc))]
                [match #f]))
+
+(define (dom-rematch! dom)
+  (set-dom-match! dom (build-match (dom-elements dom) (dom-boxes dom))))
 
 (define (build-match elts boxes)
   (define num->elt (make-hasheq))

--- a/src/execute.rkt
+++ b/src/execute.rkt
@@ -42,12 +42,23 @@
         [`(let ,var ,expr)
          (format "var ~a = ~a;" var (expr->js expr))]
         [`(set ,var ,field ,expr)
-         (format "~a.~a = ~a;" var (expr->js field) (expr->js expr))]
+         (format "~a.~a = ~a;" var (field->js field) (expr->js expr))]
         [`(append-child ,elt ,child)
          (format "~a.appendChild(~a);" (expr->js elt) (expr->js child))]))
     (set! js-lines (cons str js-lines)))
   (set! js-lines (cons "}" js-lines))
   (string-join (reverse js-lines) "\n"))
+
+(define (field->js field)
+  (match field
+    [`(quote ,elt)
+      (match elt
+	[':id
+	  "id"]
+	[':text
+	 "innerText"]
+	[else
+	  (raise (format "~a not supported" elt))])]))
 
 (define (expr->js expr)
   (match expr
@@ -59,13 +70,5 @@
           (format "document.createElement('~a')" element)]
        [else
 	 (raise "Bad input for create")])]
-    [`(quote ,elt)
-      (match elt
-	[':id
-	  "id"]
-	[':text
-	 "innerText"]
-	[else
-	  (raise (format "~a not supported" elt))])]
     [else
       expr]))

--- a/src/execute.rkt
+++ b/src/execute.rkt
@@ -1,5 +1,6 @@
 #lang racket
 
+(require "print/css.rkt")
 (provide execute-script script->js)
 
 
@@ -50,14 +51,14 @@
 
 (define (expr->js expr)
   (match expr
-    [`(select ,sel) ;;todo use selector->string
-      (match sel
-	[(list 'id elt-id)
-	 (format "document.getElementById(\"~a\")" elt-id)] 
-	[else
-	  (raise (format "unsupported selector ~a" sel))])]
+    [`(select ,sel) 
+       (format "document.querySelector(\"~a\")" (selector->string sel))] 
     [`(create ,elt)
-      (format "document.createElement('~a')" (list-ref elt 0))] ;;TODO write a match
+      (match elt 
+       [(list element)
+          (format "document.createElement('~a')" element)]
+       [else
+	 (raise "Bad input for create")])]
     [`(quote ,elt)
       (match elt
 	[':id

--- a/src/execute.rkt
+++ b/src/execute.rkt
@@ -1,0 +1,50 @@
+#lang racket
+
+(provide execute-script script->js)
+
+
+(define (execute-script lines)
+  (define environment (make-hash))
+  (define effects '())
+  (for ([line (in-list lines)])
+    (match line
+      [`(let ,var ,expr)
+       (define val (evaluate-expr expr environment))
+       (hash-set! environment var val)]
+      [`(set ,var ,field ,expr)
+       (void)]
+      [`(append-child ,elt ,child)
+       (define elt* (evaluate-expr elt environment))
+       (define child* (evaluate-expr child environment))
+       (define box (elt->box child*))
+       (set! effects (cons (list 'append-child elt* child* box) effects))]))
+  (reverse effects))
+
+(define (evaluate-expr expr env)
+  (match expr
+    [(? symbol?)
+     (hash-ref env expr)]
+    [`(select ,sel)
+     sel]
+    [`(create ,tree)
+     tree]))
+
+(define (elt->box tree)
+  '[BLOCK])
+
+(define (script->js lines)
+  (define lines '())
+  (for ([line (in-list lines)])
+    (define str
+      (match line
+        [`(let ,var ,expr)
+         (format "var ~a = ~a;" var (expr->js expr))]
+        [`(set ,var ,field ,expr)
+         (format "~a.~a = ~a;" var field (expr->js expr))]
+        [`(append-child ,elt ,child)
+         (format "~a.appendChild(~a)" (expr->js elt) (expr->js child))]))
+    (set! lines (cons str lines)))
+  (string-join (reverse lines) "\n"))
+
+(define (expr->js expr)
+  expr)

--- a/src/input.rkt
+++ b/src/input.rkt
@@ -17,6 +17,8 @@
   (parameterize ([read-decimal-as-inexact false])
     (for ([expr (in-port read port)])
       (match expr
+	[`(define-script ,name ,script)
+	  (dict-set! scripts name script)]
         [`(define-stylesheet ,name ,rules ...)
          (dict-set! sheets name
                     (for/list ([rule rules])
@@ -44,6 +46,7 @@
 
          (get-from ':sheets sheets)
          (get-from ':layouts layouts)
+	 (get-from ':script scripts)
          (set! properties (dict-set properties ':documents (dict-ref properties ':layouts)))
          (set! properties
                (dict-set properties ':fonts

--- a/src/modularize.rkt
+++ b/src/modularize.rkt
@@ -202,14 +202,11 @@
   (define list-dom (parse-dom component-document))
   (define list-box (dom-boxes list-dom))
   (define list-elt (dom-box->elt list-dom list-box))
-  (define node-info (node-get* list-box ':node-info))
+  (define box-info (node-get* list-box ':box-info))
   (define elt-info (node-get* list-box ':elt-info))
-  (when node-info
-    (pretty-print node-info)
-    (pretty-print elt-info))
   (define ind-fact (node-get* list-box ':inductive-fact))
   (define name (node-get list-box ':name))
-
+ 
   ;;If the list has an inductive fact and it has 4 or more elements, set up a proof by induction
   (cond
     ;;When no induction is requested, do nothing
@@ -231,7 +228,7 @@
        (raise-user-error 'induct "Can not induct over ~a because its element's children are too dissimilar" name))
      (when (< (length (node-children list-box)) 4)
        (eprintf "Warning: Adding elements to inductive component ~a.\n" name)
-       (inductive-add-elements! list-box list-elt))
+       (inductive-add-elements! list-dom list-box list-elt))
 
      (when (> (length (node-children list-box)) 4)
        (eprintf "Warning: Removing elements from inductive component ~a.\n" name)
@@ -239,13 +236,15 @@
      (for/list ([fn (list one-case two-case three-case base-case ind-case thm-case)])
        (fn (unparse-dom list-dom) precondition postcondition ind-fact))]))
 
-(define (inductive-add-elements! list-box list-elt)
+(define (inductive-add-elements! list-dom list-box list-elt)
   (while (< (length (node-children list-box)) 4)
     (define box-clone (clone-node (node-lchild list-box)))
     (define elt-clone (clone-node (node-lchild list-elt)))
     (add-node-before! (node-lchild list-box) box-clone)
     (add-node-before! (node-lchild list-elt) elt-clone)
-    (node-set! box-clone ':elt (node-id elt-clone))))
+    (node-set! elt-clone ':num (node-id elt-clone))
+    (node-set! box-clone ':elt (node-id elt-clone))
+    (dom-rematch! list-dom)))
 
 (define (inductive-remove-elements! list-box list-elt)
   (while (< 4 (length (node-children list-box)))

--- a/src/modularize.rkt
+++ b/src/modularize.rkt
@@ -202,7 +202,11 @@
   (define list-dom (parse-dom component-document))
   (define list-box (dom-boxes list-dom))
   (define list-elt (dom-box->elt list-dom list-box))
-
+  (define node-info (node-get* list-box ':node-info))
+  (define elt-info (node-get* list-box ':elt-info))
+  (when node-info
+    (pretty-print node-info)
+    (pretty-print elt-info))
   (define ind-fact (node-get* list-box ':inductive-fact))
   (define name (node-get list-box ':name))
 

--- a/src/proofs.rkt
+++ b/src/proofs.rkt
@@ -85,7 +85,8 @@
 	      (when (node-get box ':inductive-fact)
 		(raise (format "~a can not be inducted over more than once" box)))
 	      (node-set! box ':inductive-fact inductive-fact))]
-	
+      ;;Allow the user to state that a given node will be appended to a given list
+	[`(append-list ,name ,node-info)]	
       ;;Given a name and type of value this command erases all values of that type from the component with the given name
       [`(erase ,name ,type)
        (define boxes (box-set name box-context))

--- a/src/proofs.rkt
+++ b/src/proofs.rkt
@@ -86,7 +86,12 @@
 		(raise (format "~a can not be inducted over more than once" box)))
 	      (node-set! box ':inductive-fact inductive-fact))]
       ;;Allow the user to state that a given node will be appended to a given list
-	[`(append-list ,name ,node-info)]	
+	[`(append-list ,name ,node-info ,elt-info)
+	  (define boxes (box-set name box-context))
+	  (for* ([box (in-list boxes)])
+		(node-set! box ':append #t)
+		(node-set! box ':node-info node-info)
+		(node-set! box ':elt-info elt-info))]	
       ;;Given a name and type of value this command erases all values of that type from the component with the given name
       [`(erase ,name ,type)
        (define boxes (box-set name box-context))

--- a/src/proofs.rkt
+++ b/src/proofs.rkt
@@ -203,10 +203,15 @@
      (hash-set! problem-context name problem*)]
     ;;Creates a new page with a given name by running a script on an already loaded page
     [`(page ,name (run-js ,old-page ,script-name))
+      ;;Check that the sudoscript translates to javascript that does what the javascript in the provided file does
+      (define generated-js (script->js (hash-ref problem-context script-name) script-name))
+      (define problem* (hash-ref problem-context old-page))
+      (define provided-js (substring (first (dict-ref problem* ':script)) 1 (- (string-length (first (dict-ref problem* ':script))) 1)))
+      (when (not (equal? generated-js provided-js))
+	(raise (format "Page script and proof script do not match, can not verify this page\n Page Script: ~a\n Proof Script: ~a\n" provided-js generated-js)))
       ;;Compute the list of changes this script can perform on the page
       (define effects (execute-script (hash-ref problem-context script-name)))
       ;;Pull the problem of the old-page out of the context
-      (define problem* (hash-ref problem-context old-page))
       (define the-dom* (first (dict-ref problem* ':documents)))
       ;;Itterate through the effects of the script, changing the page in the needed ways when certain effects appear
       (for ([effect effects])


### PR DESCRIPTION
For the purposes of supporting JavaScript a proof strategy needs to be added that explains the effects of a given script on the webpage. The append-list strategy will fullfill this role for a piece of JS that adds to a list on a webpage. To support this it will add a new child to the list of children of a given list object, and than attempt to prove the proofs theorems on that list, using any induction the user attempted to apply.

- [x]  Edit proofs.rkt to allow the user to put this proof strategy in their proof
- [x]  Edit modularize.rkt to add to the children of a list marked with append